### PR TITLE
友人紹介機能実装

### DIFF
--- a/app/controllers/enquetes_controller.rb
+++ b/app/controllers/enquetes_controller.rb
@@ -10,6 +10,7 @@ class EnquetesController < ApplicationController
     @enquete = Reservation.find(params[:reservation_id]).enquetes.build(enquete_params)
     @enquete.answer_date = Date.today
     if @enquete.save
+      introduction_point_add
       redirect_to mypage_url, notice: 'アンケートを送信しました'
     else
       render :new
@@ -22,5 +23,15 @@ class EnquetesController < ApplicationController
     params.fetch(:enquete, {}).permit(
       enquete_answers_attributes: [:enquete_item_id, :string_value, :integer_value, :boolean_value]
     )
+  end
+
+  # 友人紹介から利用したユーザーの場合、紹介者にポイント付与
+  def introduction_point_add
+    introduction = Introduction.registered&.find_by(introduced_id: current_user.id)
+    if introduction.present?
+      introduction.user.point_count += 3000
+      introduction.user.save!
+      introduction.provided!
+    end
   end
 end

--- a/app/controllers/enquetes_controller.rb
+++ b/app/controllers/enquetes_controller.rb
@@ -10,7 +10,7 @@ class EnquetesController < ApplicationController
     @enquete = Reservation.find(params[:reservation_id]).enquetes.build(enquete_params)
     @enquete.answer_date = Date.today
     if @enquete.save
-      introduction_point_add
+      current_user.passive_introduction.point_add
       redirect_to mypage_url, notice: 'アンケートを送信しました'
     else
       render :new
@@ -25,13 +25,4 @@ class EnquetesController < ApplicationController
     )
   end
 
-  # 友人紹介から利用したユーザーの場合、紹介者にポイント付与
-  def introduction_point_add
-    introduction = Introduction.registered&.find_by(introduced_id: current_user.id)
-    if introduction.present?
-      introduction.user.point_count += 3000
-      introduction.user.save!
-      introduction.provided!
-    end
-  end
 end

--- a/app/controllers/introductions_controller.rb
+++ b/app/controllers/introductions_controller.rb
@@ -1,0 +1,31 @@
+class IntroductionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @introduction = current_user.introductions.new
+  end
+
+  def create
+    @introduction = current_user.introductions.new(introduction_params)
+    @introduction.introduction_token = SecureRandom.urlsafe_base64
+
+    if @introduction.save
+      send_introduction_mail
+      redirect_to mypage_path, notice: '招待メールを送信しました。'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def introduction_params
+    params.fetch(:introduction, {}).permit(
+      :introduced_email
+    )
+  end
+
+  def send_introduction_mail
+    IntroductionMailer.introduction_mail(@introduction).deliver_now
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,6 +2,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
   prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy, :password_edit ,:password_update]
+  before_action :set_introduction_params, only: [:new]
+  after_action :introduction_registrate, only: [:create]
 
   # GET /resource/sign_up
   # def new
@@ -83,6 +85,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
     params.fetch(:user, {}).permit(
       :password, :password_confirmation, :current_password
     )
+  end
+
+  def set_introduction_params
+    session[:introduction_token] = params[:introduction_token] unless params[:introduction_token].blank?
+  end
+
+  def introduction_registrate
+    if session[:introduction_token].present? && resource.persisted?
+      introduction = Introduction.find_by(introduction_token: session[:introduction_token])
+      introduction.registrate(resource.id)
+      session.delete(:introduction_token)
+    end
   end
 
   protected

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -91,10 +91,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session[:introduction_token] = params[:introduction_token] unless params[:introduction_token].blank?
   end
 
+  # 紹介されたユーザーの場合、紹介ステータスの更新&ユーザーID登録
   def introduction_registrate
     if session[:introduction_token].present? && resource.persisted?
-      introduction = Introduction.find_by(introduction_token: session[:introduction_token])
-      introduction.registrate(resource.id)
+      Introduction.by_token(session[:introduction_token]).registrate(resource.id)
       session.delete(:introduction_token)
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -88,13 +88,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def set_introduction_params
-    session[:introduction_token] = params[:introduction_token] unless params[:introduction_token].blank?
+    session[:introduction_token] = params[:introduction_token] if params[:introduction_token].present?
   end
 
   # 紹介されたユーザーの場合、紹介ステータスの更新&ユーザーID登録
   def introduction_registrate
     if session[:introduction_token].present? && resource.persisted?
-      Introduction.by_token(session[:introduction_token]).registrate(resource.id)
+      Introduction.find_by_token(session[:introduction_token]).registrate(resource.id)
       session.delete(:introduction_token)
     end
   end

--- a/app/mailers/introduction_mailer.rb
+++ b/app/mailers/introduction_mailer.rb
@@ -1,0 +1,9 @@
+class IntroductionMailer < ApplicationMailer
+  default template_path: 'mailers/introduction_mailer'
+  default from: Settings.mail.from
+
+  def introduction_mail(introduction)
+    @introduction = introduction
+    mail(to: @introduction.introduced_email, subject: 'nominiへの招待メールが届きました。')
+  end
+end

--- a/app/models/introduction.rb
+++ b/app/models/introduction.rb
@@ -1,0 +1,17 @@
+class Introduction < ApplicationRecord
+  # Association
+  belongs_to :user
+
+  # Validation
+  validates :user_id, presence: true
+  validates :introduced_email, presence: true
+  validates :introduction_token, presence: true
+
+  enum status: { sent: 0, registered: 1, provided: 2 }
+
+  def registrate(user_id)
+    self.registered! unless provided?
+    self.introduced_id = user_id
+    self.save!
+  end
+end

--- a/app/models/introduction.rb
+++ b/app/models/introduction.rb
@@ -1,6 +1,11 @@
 class Introduction < ApplicationRecord
+
+  # 紹介したユーザーに加算されるポイント
+  INTRODUCTION_POINT = 3000
+
   # Association
   belongs_to :user
+  belongs_to :introduced, class_name: "User", optional: true
 
   # Validation
   validates :user_id, presence: true
@@ -9,9 +14,22 @@ class Introduction < ApplicationRecord
 
   enum status: { sent: 0, registered: 1, provided: 2 }
 
+  # scope
+  scope :by_token, -> token { find_by(introduction_token: token) }
+
+  # 友人紹介から登録された際のステータス変更&ユーザーID登録
   def registrate(user_id)
-    self.registered! unless provided?
+    self.registered! unless self.provided?
     self.introduced_id = user_id
     self.save!
+  end
+
+  # 友人紹介から利用したユーザーの場合、紹介者にポイント付与
+  def point_add
+    if registered?
+      user.point_count += INTRODUCTION_POINT
+      user.save!
+      provided!
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :reservations
   has_one :bank_account, dependent: :destroy
   has_one :payment
+  has_many :introductions
 
   # Validation
   validates :l_name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_one :payment
   has_many :introductions, dependent: :destroy
   has_one :passive_introduction, class_name: "Introduction",
-                                 foreign_key: "introduced_id",
+                                 foreign_key: "introduced_user_id",
                                  dependent: :destroy
 
   # Validation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,10 @@ class User < ApplicationRecord
   has_many :reservations
   has_one :bank_account, dependent: :destroy
   has_one :payment
-  has_many :introductions
+  has_many :introductions, dependent: :destroy
+  has_one :passive_introduction, class_name: "Introduction",
+                                 foreign_key: "introduced_id",
+                                 dependent: :destroy
 
   # Validation
   validates :l_name, presence: true

--- a/app/views/introductions/new.html.erb
+++ b/app/views/introductions/new.html.erb
@@ -1,0 +1,12 @@
+<div class="main-area container bg-white mt-3">
+  <h2 class="text-info text-center page-heading mb-4 mt-4">友人紹介</h2>
+  <p class="text-center">紹介したご友人がnominiで店舗を利用すると、貴方に3000ポイントが付与されます。</p>
+  <%= form_for @introduction, url: introduction_path do |f| %>
+    <div class="field form-group text-center login-form">
+      <%= f.email_field :introduced_email, placeholder: t("activerecord.attributes.user.email"), class: "form-control" %>
+    </div>
+    <div class="actions form-group text-center">
+      <%= f.submit "紹介メール送信", class: "btn btn-info" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,6 +19,7 @@
             <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
               <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
               <%= link_to "ユーザー設定", edit_user_registration_path, class: "dropdown-item" %>
+              <%= link_to "友人紹介", new_introduction_path, class: "dropdown-item" %>
             </div>
           </li>
 

--- a/app/views/mailers/introduction_mailer/introduction_mail.html.erb
+++ b/app/views/mailers/introduction_mailer/introduction_mail.html.erb
@@ -1,0 +1,3 @@
+<p><%= @introduction.user.full_name %>様より、nominiへの招待が届きました。</p>
+<p>会員登録をお願いいたします。</p>
+<p><%= link_to 'nomini会員登録', new_user_registration_url(introduction_token: @introduction.introduction_token) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     get 'users/edit/password', to: 'users/registrations#password_edit'
     patch 'users/edit/password', to: 'users/registrations#password_update'
     resource :bank_account, only: [:new, :create, :edit, :update]
+    resource :introduction, only: [:new, :create]
   end
 
   get  '/mypage',    to: 'reservations#index'

--- a/db/migrate/20171022085024_create_introductions.rb
+++ b/db/migrate/20171022085024_create_introductions.rb
@@ -1,0 +1,13 @@
+class CreateIntroductions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :introductions do |t|
+      t.references :user, foreign_key: true
+      t.integer :introduced_id
+      t.string :introduced_email
+      t.string :introduction_token
+      t.integer :status, default: 0
+      t.timestamps
+    end
+    add_index :introductions, [:user_id, :introduced_id], unique: true
+  end
+end

--- a/db/migrate/20171022085024_create_introductions.rb
+++ b/db/migrate/20171022085024_create_introductions.rb
@@ -2,12 +2,12 @@ class CreateIntroductions < ActiveRecord::Migration[5.1]
   def change
     create_table :introductions do |t|
       t.references :user, foreign_key: true
-      t.integer :introduced_id
+      t.integer :introduced_user_id
       t.string :introduced_email
       t.string :introduction_token
       t.integer :status, default: 0
       t.timestamps
     end
-    add_index :introductions, [:user_id, :introduced_id], unique: true
+    add_index :introductions, [:user_id, :introduced_user_id], unique: true
   end
 end

--- a/spec/controllers/introductions_controller_spec.rb
+++ b/spec/controllers/introductions_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe IntroductionsController, type: :controller do
+
+end

--- a/spec/mailers/introduction_mailer_spec.rb
+++ b/spec/mailers/introduction_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe IntroductionMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/introduction_mailer_preview.rb
+++ b/spec/mailers/previews/introduction_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/introduction_mailer
+class IntroductionMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/models/introduction_spec.rb
+++ b/spec/models/introduction_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Introduction, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/support/factories/introductions.rb
+++ b/spec/support/factories/introductions.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :introduction do
+    
+  end
+end


### PR DESCRIPTION
# 概要
友人機能実装

# 対応内容
- 紹介モデル作成
- 紹介メール送信処理
- 登録時のID登録&ステータス変更
- アンケート回答時に紹介確定、ポイント付与

# その他
- Userとの紐付けを多対多にするか悩んだのですが、何かイメージ違うなと思い結局一対多で実装しました。
- 通常登録/facebook登録の動作確認済み