### PR TITLE
顧客からの予約内容変更

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -23,6 +23,21 @@ class ReservationsController < ApplicationController
     end
   end
 
+  def edit
+    @reservation = Reservation.find(params[:id])
+  end
+
+  def update
+    @reservation = Reservation.find(params[:id])
+    if @reservation.update(reservation_params)
+      ReservationMailer.update_reservation_to_user(@reservation).deliver_now
+      ReservationMailer.update_reservation_to_nomini(@reservation).deliver_now
+      redirect_to reservation_url(@reservation), notice: '予約内容を変更しました。'
+    else
+      render :edit
+    end
+  end
+
   def cancel
     @reservation = Reservation.find(params[:id])
     @reservation.canceled!

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -29,6 +29,16 @@ class ReservationMailer < ApplicationMailer
 
   def cancel_reservation_to_user(reservation)
     @reservation = reservation
-    mail(to: Settings.mail.to, subject: '予約をキャンセルしました')
+    mail(to: @reservation.user.email, subject: '予約をキャンセルしました')
+  end
+
+  def update_reservation_to_nomini(reservation)
+    @reservation = reservation
+    mail(to: Settings.mail.to, subject: '予約内容が変更されました')
+  end
+
+  def update_reservation_to_user(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: '予約内容を変更しました')
   end
 end

--- a/app/views/mailers/reservation_mailer/update_reservation_to_nomini.html.erb
+++ b/app/views/mailers/reservation_mailer/update_reservation_to_nomini.html.erb
@@ -1,0 +1,41 @@
+<p>nomini様</p>
+
+<p>
+  ご利用者様より予約内容が変更されました。確認してください。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/update_reservation_to_user.html.erb
+++ b/app/views/mailers/reservation_mailer/update_reservation_to_user.html.erb
@@ -1,0 +1,42 @@
+<p><%= @reservation.user.full_name %>様</p>
+
+<p>
+  予約内容を変更いたしました。<br>
+  ご確認の程、よろしくお願いいたします。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="container bg-white mt-3 pb-2">
+  <h2 class="text-info py-3 m-0">予約内容変更</h2>
+  <ul class="reservation-chack text-danger">
+    <% @reservation.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+    <% end %>
+  </ul>
+  <p>店舗名</p>
+  <p class="ml-2 font-weight-bold"><%= @reservation.shop&.name %></p>
+  <%= bootstrap_form_for (@reservation), url: reservation_path(@reservation) do |form| %>
+    <%= form.select :reservation_category_id, @reservation.shop.valid_categories_list, label: "予約カテゴリ" %>
+    <%= form.select :people_count, (1..30).map {|num| num.to_s + "名"}  %>
+    <%= form.text_field :use_date, id: "datetimepicker" %>
+    <%= form.time_select :use_time, minute_step: 10 %>
+    <%= form.text_area :message %>
+
+    <div class="box-footer text-center mb-2">
+      <%= form.primary '上記内容で予約情報を変更する', class: "btn btn-info" %>
+    </div>
+  <% end %>
+</div>
+
+<script type="text/javascript">
+  flatpickr('#datetimepicker',{dateFormat: 'Y/m/d', allowInput: true, clickOpens: true});
+</script>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container bg-white mt-3 pb-2">
   <h2 class="text-info py-3 m-0">予約情報</h2>
   <!-- Main content -->
-  <div class="confirm-box">
+  <div class="confirm-box clearfix">
     <div class="row confirm-list">
       <div class="col-md-3">
         <h3 class="confirm-label"><%= Reservation.human_attribute_name(:shop) %></h3>
@@ -88,9 +88,9 @@
       </div>
     </div>
     <% unless @reservation.canceled? %>
-      <div class="mb-3 clearfix">
-        <%= link_to "予約をキャンセルする", cancel_reservation_path(@reservation), class: "btn btn-outline-secondary float-right", method: :patch, data: { confirm: '予約をキャンセルしてよろしいですか？' } %>
-        <%= link_to "予約内容を変更する", edit_reservation_path(@reservation), class: "btn btn-outline-info float-right mr-2" %>
+      <div class="mb-2 float-right">
+        <%= link_to "予約内容を変更する", edit_reservation_path(@reservation), class: "btn btn-outline-info mr-2 mb-1" %>
+        <%= link_to "予約をキャンセルする", cancel_reservation_path(@reservation), class: "btn btn-outline-secondary mb-1", method: :patch, data: { confirm: '予約をキャンセルしてよろしいですか？' } %>
       </div>
     <% end %>
   </div>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -90,6 +90,7 @@
     <% unless @reservation.canceled? %>
       <div class="mb-3 clearfix">
         <%= link_to "予約をキャンセルする", cancel_reservation_path(@reservation), class: "btn btn-outline-secondary float-right", method: :patch, data: { confirm: '予約をキャンセルしてよろしいですか？' } %>
+        <%= link_to "予約内容を変更する", edit_reservation_path(@reservation), class: "btn btn-outline-info float-right mr-2" %>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   get  '/mypage',    to: 'reservations#index'
 
   resources :shops, only: [:index, :show], shallow: true do
-    resources :reservations, only: [:index, :show, :create, :confirm, :cancel] do
+    resources :reservations, only: [:index, :show, :create, :edit, :update, :confirm, :cancel] do
       post :confirm, on: :collection
       patch :cancel, on: :member
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   get  '/mypage',    to: 'reservations#index'
 
   resources :shops, only: [:index, :show], shallow: true do
-    resources :reservations, only: [:index, :show, :create, :edit, :update, :confirm, :cancel] do
+    resources :reservations, except: [:new] do
       post :confirm, on: :collection
       patch :cancel, on: :member
     end


### PR DESCRIPTION
# 概要
顧客からの予約情報変更実装

# 作業内容
- 予約詳細画面に予約内容変更リンク表示
- 予約カテゴリ/人数/日付/時刻を変更する画面を作成
- 予約内容変更時に管理者、ユーザーへのメール送信

# その他
内容変更可能かの制御、変更可能な要素については要確認