### PR TITLE
店舗ページからの予約作成機能追加

### DIFF
--- a/app/controllers/shop_page/reservations_controller.rb
+++ b/app/controllers/shop_page/reservations_controller.rb
@@ -44,8 +44,8 @@ class ShopPage::ReservationsController < ShopPageController
   end
 
   def send_reservation_mail
-    ReservationMailer.notice_reservation_to_nomini(@reservation).deliver_now
-    ReservationMailer.notice_reservation_to_user(@reservation).deliver_now
+    ReservationMailer.notice_reservation_to_nomini_from_shop(@reservation).deliver_now
+    ReservationMailer.notice_reservation_to_user_from_shop(@reservation).deliver_now
   end
 
 

--- a/app/controllers/shop_page/reservations_controller.rb
+++ b/app/controllers/shop_page/reservations_controller.rb
@@ -4,4 +4,49 @@ class ShopPage::ReservationsController < ShopPageController
     @reservations = current_shop.reservations.page(params[:page])
   end
 
+  def new
+    @reservation = current_shop.reservations.build
+  end
+
+  def create
+    @reservation = Reservation.new(reservation_params)
+    @reservation.user = User.find(params[:reservation][:customer_id])
+    @reservation.shop = current_shop
+    if params[:back].blank? && @reservation.save
+      send_reservation_mail
+      redirect_to shop_page_root_path, notice: '予約を作成しました。'
+    else
+      render :new
+    end
+  end
+
+  def confirm
+    @customer_user = User.find_by(phone_number: params[:reservation][:phone_number])
+    @reservation = Reservation.new(reservation_params)
+    if @customer_user.blank?
+      @reservation.errors[:base] << 'お客様情報が見つかりませんでした。'
+      render :new and return
+    end
+    @reservation.user_id = @customer_user&.id
+    @reservation.shop_id = current_shop.id
+    unless @reservation.valid?
+      render :new
+    end
+  end
+
+  private
+
+  def reservation_params
+    params.fetch(:reservation, {}).permit(
+      :shop_id, :user_id, :reservation_category_id, :people_count,
+      :use_date, :use_time, :message, :status
+    )
+  end
+
+  def send_reservation_mail
+    ReservationMailer.notice_reservation_to_nomini(@reservation).deliver_now
+    ReservationMailer.notice_reservation_to_user(@reservation).deliver_now
+  end
+
+
 end

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -41,4 +41,14 @@ class ReservationMailer < ApplicationMailer
     @reservation = reservation
     mail(to: @reservation.user.email, subject: '予約内容を変更しました')
   end
+
+  def notice_reservation_to_nomini_from_shop(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: '店舗が予約を受理しました')
+  end
+
+  def notice_reservation_to_user_from_shop(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: 'nomini店舗予約詳細')
+  end
 end

--- a/app/views/layouts/shop_page/_header.html.erb
+++ b/app/views/layouts/shop_page/_header.html.erb
@@ -1,7 +1,7 @@
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
 <nav class="navbar navbar-light">
   <div class="container">
-    <%= link_to "nomini 店舗管理画面", mypage_path, class: "navbar-brand text-muted"%>
+    <%= link_to "nomini 店舗管理画面", shop_page_root_path, class: "navbar-brand text-muted"%>
     <ul class="nav">
       <li class="dropdown nav-item mr-3 align-self-center user-menu">
         <button class="btn-link dropdown-toggle user-info" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/mailers/introduction_mailer/introduction_mail.html.erb
+++ b/app/views/mailers/introduction_mailer/introduction_mail.html.erb
@@ -1,3 +1,3 @@
-<p><%= @introduction.user.full_name %>様より、nominiへの招待が届きました。</p>
+<p><%= @introduction.user.full_name_kana %>様より、nominiへの招待が届きました。</p>
 <p>会員登録をお願いいたします。</p>
 <p><%= link_to 'nomini会員登録', new_user_registration_url(introduction_token: @introduction.introduction_token) %></p>

--- a/app/views/mailers/reservation_mailer/cancel_reservation_to_nomini.html.erb
+++ b/app/views/mailers/reservation_mailer/cancel_reservation_to_nomini.html.erb
@@ -26,7 +26,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/cancel_reservation_to_user.html.erb
+++ b/app/views/mailers/reservation_mailer/cancel_reservation_to_user.html.erb
@@ -1,4 +1,4 @@
-<p><%= @reservation.user.full_name %>様</p>
+<p><%= @reservation.user.full_name_kana %>様</p>
 
 <p>
   予約をキャンセルいたしました。<br>
@@ -27,7 +27,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/done_reservation_to_user.html.erb
+++ b/app/views/mailers/reservation_mailer/done_reservation_to_user.html.erb
@@ -1,4 +1,4 @@
-<p><%= @reservation.user.full_name %>様</p>
+<p><%= @reservation.user.full_name_kana %>様</p>
 
 <p>
   予約が承認されました。<br>
@@ -27,7 +27,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/notice_reservation_to_nomini.html.erb
+++ b/app/views/mailers/reservation_mailer/notice_reservation_to_nomini.html.erb
@@ -26,7 +26,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/notice_reservation_to_nomini_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/notice_reservation_to_nomini_from_shop.html.erb
@@ -26,7 +26,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/notice_reservation_to_nomini_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/notice_reservation_to_nomini_from_shop.html.erb
@@ -1,0 +1,41 @@
+<p>nomini様</p>
+
+<p>
+  電話予約が行われました。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/notice_reservation_to_user.html.erb
+++ b/app/views/mailers/reservation_mailer/notice_reservation_to_user.html.erb
@@ -1,4 +1,4 @@
-<p><%= @reservation.user.full_name %>様</p>
+<p><%= @reservation.user.full_name_kana %>様</p>
 
 <p>
   ご予約いただきありがとうございます。<br>
@@ -27,7 +27,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/notice_reservation_to_user_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/notice_reservation_to_user_from_shop.html.erb
@@ -1,0 +1,42 @@
+<p><%= @reservation.user.full_name %>様</p>
+
+<p>
+  ご予約いただきありがとうございます。<br>
+  予約確定を行なってください。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/notice_reservation_to_user_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/notice_reservation_to_user_from_shop.html.erb
@@ -1,4 +1,4 @@
-<p><%= @reservation.user.full_name %>様</p>
+<p><%= @reservation.user.full_name_kana %>様</p>
 
 <p>
   ご予約いただきありがとうございます。<br>
@@ -27,7 +27,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/remand_reservation_to_user.html.erb
+++ b/app/views/mailers/reservation_mailer/remand_reservation_to_user.html.erb
@@ -1,4 +1,4 @@
-<p><%= @reservation.user.full_name %>様</p>
+<p><%= @reservation.user.full_name_kana %>様</p>
 
 <p>
   予約がキャンセルされました。<br>
@@ -27,7 +27,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/update_reservation_to_nomini.html.erb
+++ b/app/views/mailers/reservation_mailer/update_reservation_to_nomini.html.erb
@@ -26,7 +26,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/mailers/reservation_mailer/update_reservation_to_user.html.erb
+++ b/app/views/mailers/reservation_mailer/update_reservation_to_user.html.erb
@@ -1,4 +1,4 @@
-<p><%= @reservation.user.full_name %>様</p>
+<p><%= @reservation.user.full_name_kana %>様</p>
 
 <p>
   予約内容を変更いたしました。<br>
@@ -27,7 +27,7 @@
   </li>
   <li>
     <h4>予約者</h4>
-    <p><%= @reservation.user.full_name %></p>
+    <p><%= @reservation.user.full_name_kana %></p>
   </li>
   <li>
     <h4>金額</h4>

--- a/app/views/shop_page/reservations/confirm.html.erb
+++ b/app/views/shop_page/reservations/confirm.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div class="col-md-9">
           <p class="confirm-value">
-            <%= @customer_user.l_name_kana %>
+            <%= @customer_user.l_name_kana %>様
           </p>
         </div>
       </div>

--- a/app/views/shop_page/reservations/confirm.html.erb
+++ b/app/views/shop_page/reservations/confirm.html.erb
@@ -1,0 +1,83 @@
+<div class="container bg-white mt-3 pb-2">
+  <h2 class="text-info py-3 m-0">予約情報確認</h2>
+  <!-- Main content -->
+  <div class="confirm-box">
+      <div class="row confirm-list">
+        <div class="col-md-3">
+          <h3 class="confirm-label">お客様のお名前</h3>
+        </div>
+        <div class="col-md-9">
+          <p class="confirm-value">
+            <%= @customer_user.l_name_kana %>
+          </p>
+        </div>
+      </div>
+      <div class="row confirm-list">
+        <div class="col-md-3">
+          <h3 class="confirm-label"><%= Reservation.human_attribute_name(:reservation_category) %></h3>
+        </div>
+        <div class="col-md-9">
+          <p class="confirm-value">
+            <%= @reservation.reservation_category&.name %>
+          </p>
+        </div>
+      </div>
+
+      <div class="row confirm-list">
+        <div class="col-md-3">
+          <h3 class="confirm-label">料金</h3>
+        </div>
+        <div class="col-md-9">
+          <p class="confirm-value">
+            <%= @reservation.output_price %>円
+          </p>
+        </div>
+      </div>
+
+      <div class="row confirm-list">
+        <div class="col-md-3">
+          <h3 class="confirm-label"><%= Reservation.human_attribute_name(:people_count) %></h3>
+        </div>
+        <div class="col-md-9">
+          <p class="confirm-value">
+            <%= @reservation.people_count %>人
+          </p>
+        </div>
+      </div>
+
+      <div class="row confirm-list">
+        <div class="col-md-3">
+          <h3 class="confirm-label"><%= Reservation.human_attribute_name(:use_datetime) %></h3>
+        </div>
+        <div class="col-md-9">
+          <p class="confirm-value">
+            <%= l(@reservation.use_date, format: :long)  %>
+            <%= @reservation.use_time.strftime("%H時%M分") %>
+          </p>
+        </div>
+      </div>
+
+      <div class="row confirm-list mb-3">
+        <div class="col-md-3">
+          <h3 class="confirm-label"><%= Reservation.human_attribute_name(:message) %></h3>
+        </div>
+        <div class="col-md-9">
+          <%= simple_format(@reservation.message, class: "message-format") %>
+        </div>
+      </div>
+
+      <div class="confirm-form mt-3 mb-2">
+        <%= form_for @reservation, url: shop_page_reservations_path(@reservation) do |f| %>
+          <%= f.hidden_field :customer_id, value: @customer_user.id %>
+          <%= f.hidden_field :people_count %>
+          <%= f.hidden_field :use_date %>
+          <%= f.hidden_field :use_time %>
+          <%= f.hidden_field :message %>
+          <%= f.hidden_field :reservation_category_id %>
+          <%= f.submit '戻る', name: 'back', class: "btn btn-outline-secondary" %>
+          <%= f.submit '予約確定', class: "btn btn-info" %>
+        <% end %>
+      </div>
+
+    </div>
+</div>

--- a/app/views/shop_page/reservations/index.html.erb
+++ b/app/views/shop_page/reservations/index.html.erb
@@ -1,5 +1,8 @@
 <div class="main-area container bg-white mt-3">
-  <h2 class="text-info page-heading py-3 m-0">予約履歴一覧</h2>
+  <h2 class="text-info page-heading py-3 m-0 float-left">予約履歴一覧</h2>
+  <div class="float-right">
+    <%= link_to "予約を作成する", new_shop_page_reservation_path, class: "btn btn-info mt-2" %>
+  </div>
   <div class="px-3">
     <div class="box box-primary">
       <div class="box-body no-padding">

--- a/app/views/shop_page/reservations/new.html.erb
+++ b/app/views/shop_page/reservations/new.html.erb
@@ -1,0 +1,47 @@
+<div class="main-area container bg-white mt-3 pb-3">
+  <h2 class="text-info text-center page-heading mb-4 mt-4">予約情報入力</h2>
+  <ul class="reservation-chack text-danger text-center list-unstyled">
+    <% @reservation.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+    <% end %>
+  </ul>
+  <%= form_with model: @reservation, url: confirm_shop_page_reservations_url, local: true do |form| %>
+    <div class="field form-group row center-form">
+      <%= form.label 'お客様の電話番号', class: "col-sm-4 signup-label m-0" %>
+      <%= form.text_field :phone_number, placeholder: 'ハイフンなしで入力してください。', class: "col-sm-8 form-control" %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :reservation_category_id, class: "col-sm-4 signup-label m-0" %>
+      <%= form.select :reservation_category_id, current_shop.valid_categories_list, {label: "予約カテゴリ"}, { class: "col-sm-8 form-control" } %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :people_count, class: "col-sm-4 signup-label m-0" %>
+      <%= form.select :people_count, (1..30).map {|num| num.to_s + "名"}, {}, { class: "col-sm-8 form-control" } %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :use_date, class: "col-sm-4 signup-label m-0" %>
+      <%= form.text_field :use_date, id: "datetimepicker", class: "col-sm-8 form-control" %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :use_time, class: "col-sm-4 signup-label m-0" %>
+      <%= form.time_select :use_time, { minute_step: 10 }, { class: "col-sm-3 form-control" } %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :message, class: "col-sm-4 signup-label m-0" %>
+      <%= form.text_area :message, class: "col-sm-8 form-control" %>
+    </div>
+
+    <div class="box-footer text-center">
+      <%= form.submit '予約情報を確認する', class: "btn btn-info" %>
+    </div>
+  <% end %>
+</div>
+
+<script type="text/javascript">
+  flatpickr('#datetimepicker',{dateFormat: 'Y/m/d', allowInput: true, clickOpens: true});
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
 
   namespace :shop_page do
     root 'reservations#index'
-    resources :reservations, only: [:index]
+    resources :reservations, only: [:index, :new, :create, :confirm] do
+      post :confirm, on: :collection
+    end
   end
 
   # deviseルーティングより前に置かないと優先度で負けるため先に記載


### PR DESCRIPTION
# 概要
利用者が電話予約した際に使用される店舗向けの予約作成機能を作成

# 作業内容
- 店舗トップページに予約作成ボタンを作成
- 電話番号から顧客を検索し、予約情報を作成
- 予約情報が作成された際に、ユーザー、nominiにメールを送信
- 登録内容が変更されたため、メールに表示されるフルネームのパラメータを変更