### PR TITLE
店舗用ページの詳細画面、予約情報更新、キャンセル実装

### DIFF
--- a/app/controllers/shop_page/reservations_controller.rb
+++ b/app/controllers/shop_page/reservations_controller.rb
@@ -16,8 +16,8 @@ class ShopPage::ReservationsController < ShopPageController
     @reservation = Reservation.new(reservation_params)
     @reservation.user = User.find(params[:reservation][:customer_id])
     @reservation.shop = current_shop
+    @reservation.done!
     if params[:back].blank? && @reservation.save
-      @reservation.done!
       send_reservation_mail
       redirect_to shop_page_root_path, notice: '予約を作成しました。'
     else

--- a/app/controllers/shop_page/reservations_controller.rb
+++ b/app/controllers/shop_page/reservations_controller.rb
@@ -1,7 +1,7 @@
 class ShopPage::ReservationsController < ShopPageController
 
   def index
-    @reservations = current_shop.reservations.page(params[:page])
+    @reservations = current_shop.reservations.includes(:user).page(params[:page])
   end
 
   def show

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -51,4 +51,24 @@ class ReservationMailer < ApplicationMailer
     @reservation = reservation
     mail(to: @reservation.user.email, subject: 'nomini店舗予約詳細')
   end
+
+  def update_reservation_to_nomini_from_shop(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: '店舗が予約変更を受理しました')
+  end
+
+  def update_reservation_to_user_from_shop(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: '予約内容を変更しました')
+  end
+
+  def cancel_reservation_to_nomini_from_shop(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: '店舗が予約キャンセルを受理しました')
+  end
+
+  def cancel_reservation_to_user_from_shop(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: '予約をキャンセルしました')
+  end
 end

--- a/app/views/mailers/reservation_mailer/cancel_reservation_to_nomini_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/cancel_reservation_to_nomini_from_shop.html.erb
@@ -1,0 +1,41 @@
+<p>nomini様</p>
+
+<p>
+  店舗より予約がキャンセルされました。確認してください。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name_kana %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/cancel_reservation_to_user_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/cancel_reservation_to_user_from_shop.html.erb
@@ -1,0 +1,42 @@
+<p><%= @reservation.user.full_name_kana %>様</p>
+
+<p>
+  予約をキャンセルいたしました。<br>
+  次のご利用をお待ちいたしましております。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name_kana %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/update_reservation_to_nomini_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/update_reservation_to_nomini_from_shop.html.erb
@@ -1,0 +1,41 @@
+<p>nomini様</p>
+
+<p>
+  店舗より予約内容が変更されました。確認してください。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name_kana %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/update_reservation_to_user_from_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/update_reservation_to_user_from_shop.html.erb
@@ -1,0 +1,42 @@
+<p><%= @reservation.user.full_name_kana %>様</p>
+
+<p>
+  予約内容を変更いたしました。<br>
+  ご確認の程、よろしくお願いいたします。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約店舗</h4>
+    <p>
+      <%= @reservation.shop.name %><br>
+      URL: <%= link_to shop_url(@reservation.shop), shop_url(@reservation.shop) %>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>予約者</h4>
+    <p><%= @reservation.user.full_name_kana %></p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+  <li>
+    <h4>備考</h4>
+    <%= simple_format(@reservation.message) %>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/shop_page/reservations/edit.html.erb
+++ b/app/views/shop_page/reservations/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="container bg-white mt-3 pb-2">
+  <h2 class="text-info py-3 m-0">予約内容変更</h2>
+  <ul class="reservation-chack text-danger">
+    <% @reservation.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+    <% end %>
+  </ul>
+  <p>お客様のお名前</p>
+  <p class="ml-2 font-weight-bold"><%= @reservation.user&.l_name_kana %>様</p>
+  <%= bootstrap_form_for (@reservation), url: shop_page_reservation_path(@reservation) do |form| %>
+    <%= form.select :reservation_category_id, @reservation.shop.valid_categories_list, label: "予約カテゴリ" %>
+    <%= form.select :people_count, (1..30).map {|num| num.to_s + "名"}  %>
+    <%= form.text_field :use_date, id: "datetimepicker" %>
+    <%= form.time_select :use_time, minute_step: 10 %>
+    <%= form.text_area :message %>
+
+    <div class="box-footer text-center mb-2">
+      <%= form.primary '上記内容で予約情報を変更する', class: "btn btn-info" %>
+    </div>
+  <% end %>
+</div>
+
+<script type="text/javascript">
+  flatpickr('#datetimepicker',{dateFormat: 'Y/m/d', allowInput: true, clickOpens: true});
+</script>

--- a/app/views/shop_page/reservations/index.html.erb
+++ b/app/views/shop_page/reservations/index.html.erb
@@ -17,23 +17,23 @@
               <% @reservations.each do |reservation| %>
                 <tr class="row reservation-tr">
                   <td class="col-sm-3 p-0 reservation-datetime">
-                    <%= link_to reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
+                    <%= link_to shop_page_reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
                       <%= l(reservation.use_date, format: :long)  %>
                       <%= reservation.use_time.strftime("%H時%M分") %>
                     <% end %>
                   </td>
                   <td class="col-sm-3 p-0">
-                    <%= link_to reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
+                    <%= link_to shop_page_reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
                       <%= reservation.user&.full_name_kana %>
                     <% end %>
                   </td>
                   <td class="col-sm-3 p-0">
-                    <%= link_to reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
+                    <%= link_to shop_page_reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
                       <%= reservation.user&.phone_number %>
                     <% end %>
                   </td>
                   <td class="col-sm-3 p-0">
-                    <%= link_to reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
+                    <%= link_to shop_page_reservation_path(reservation), class: 'd-block p-2 text-black reservation-td' do %>
                       <%= reservation.status_i18n %>
                     <% end %>
                   </td>

--- a/app/views/shop_page/reservations/show.html.erb
+++ b/app/views/shop_page/reservations/show.html.erb
@@ -1,0 +1,97 @@
+<div class="container bg-white mt-3 pb-2">
+  <h2 class="text-info py-3 m-0">予約情報</h2>
+  <!-- Main content -->
+  <div class="confirm-box clearfix">
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label">お客様のお名前</h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation.user&.l_name_kana %>様
+        </p>
+      </div>
+    </div>
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:reservation_category) %></h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation.reservation_category&.name %>
+        </p>
+      </div>
+    </div>
+
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label">料金</h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation.output_price %>円
+        </p>
+      </div>
+    </div>
+
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:people_count) %></h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation.people_count %>人
+        </p>
+      </div>
+    </div>
+
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:use_datetime) %></h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= l(@reservation.use_date, format: :long)  %>
+          <%= @reservation.use_time.strftime("%H時%M分") %>
+        </p>
+      </div>
+    </div>
+
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:message) %></h3>
+      </div>
+      <div class="col-md-9">
+        <%= simple_format(@reservation.message, class: "message-format") %>
+      </div>
+    </div>
+
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:status) %></h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation.status_i18n %>
+        </p>
+      </div>
+    </div>
+
+    <div class="row confirm-list mb-3">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:created_at) %></h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= l(@reservation.created_at, format: :default) %>
+        </p>
+      </div>
+    </div>
+    <% unless @reservation.canceled? %>
+      <div class="mb-2 float-right">
+        <%= link_to "予約内容を変更する", edit_shop_page_reservation_path(@reservation), class: "btn btn-outline-info mr-2 mb-1" %>
+        <%= link_to "予約をキャンセルする", cancel_shop_page_reservation_path(@reservation), class: "btn btn-outline-secondary mb-1", method: :patch, data: { confirm: '予約をキャンセルしてよろしいですか？' } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,9 @@ Rails.application.routes.draw do
 
   namespace :shop_page do
     root 'reservations#index'
-    resources :reservations, only: [:index, :new, :create, :confirm] do
+    resources :reservations do
       post :confirm, on: :collection
+      patch :cancel, on: :member
     end
   end
 


### PR DESCRIPTION
# 概要
店舗用ページにおける
- 予約詳細確認
- 予約内容変更
- キャンセル

# 作業内容
- 詳細確認実装
- 予約内容変更処理実装
- 予約キャンセル実装
- 店舗側の場合、予約作成のタイミングで承認済みにステータス変更
- 各種メーラー実装

# その他
仕様書見返してみたところ、返金フローについては店舗側が行う想定に見受けられたため、このような実装になります。