### PR TITLE
決済周りの処理作成

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -4,4 +4,5 @@ require 'capistrano/rails'
 require 'capistrano/rbenv'
 require 'capistrano/bundler'
 require 'capistrano3/unicorn'
+require 'whenever/capistrano'
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'payjp'
 gem 'dotenv-rails'
 gem 'config'
 gem 'enum_help'
+gem 'whenever', require: false
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -502,6 +503,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
@@ -551,6 +554,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   web-console (>= 3.3.0)
+  whenever
 
 BUNDLED WITH
    1.15.4

--- a/app/controllers/reservation_payments_controller.rb
+++ b/app/controllers/reservation_payments_controller.rb
@@ -1,0 +1,21 @@
+class ReservationPaymentsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_reservation_payment
+
+  def show
+  end
+
+  def update
+    if @reservation_payment.liquidation(params)
+      redirect_to mypage_url, notice: '決済を完了しました'
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def set_reservation_payment
+    @reservation_payment = ReservationPayment.find(params[:id])
+  end
+end

--- a/app/controllers/shop_page/payments_controller.rb
+++ b/app/controllers/shop_page/payments_controller.rb
@@ -7,6 +7,7 @@ class ShopPage::PaymentsController < ApplicationController
     @reservation = Reservation.find(params[:reservation_id])
     @reservation_payment = @reservation.setting_payment(reservation_payment_params)
     if @reservation_payment.save
+      PaymentMailer.notification(@reservation_payment).deliver_now
       redirect_to shop_page_root_url, notice: '支払い情報を確定しました。'
     else
       render :new

--- a/app/controllers/shop_page/payments_controller.rb
+++ b/app/controllers/shop_page/payments_controller.rb
@@ -1,0 +1,21 @@
+class ShopPage::PaymentsController < ApplicationController
+  def new
+    @reservation_payment = Reservation.find(params[:reservation_id]).setting_payment
+  end
+
+  def create
+    @reservation = Reservation.find(params[:reservation_id])
+    @reservation_payment = @reservation.setting_payment(reservation_payment_params)
+    if @reservation_payment.save
+      redirect_to shop_page_root_url, notice: '支払い情報を確定しました。'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def reservation_payment_params
+    params.fetch(:reservation_payment, {}).permit(:amount)
+  end
+end

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -1,0 +1,9 @@
+class PaymentMailer < ApplicationMailer
+  default template_path: 'mailers/payment_mailer'
+  default from: Settings.mail.from
+
+  def notification(payment)
+    @payment = payment
+    mail(to: @payment.user.email, subject: "【nomini】#{@payment.reservation.shop.name}ご利用の決済について")
+  end
+end

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -52,6 +52,7 @@ class ReservationMailer < ApplicationMailer
     mail(to: @reservation.user.email, subject: 'nomini店舗予約詳細')
   end
 
+<<<<<<< HEAD
   def update_reservation_to_nomini_from_shop(reservation)
     @reservation = reservation
     mail(to: @reservation.user.email, subject: '店舗が予約変更を受理しました')
@@ -70,5 +71,10 @@ class ReservationMailer < ApplicationMailer
   def cancel_reservation_to_user_from_shop(reservation)
     @reservation = reservation
     mail(to: @reservation.user.email, subject: '予約をキャンセルしました')
+  end
+
+  def confirm_use_price_to_shop(reservation)
+    @reservation = reservation
+    mail(to: @reservation.shop.email, subject: '【nomini】予約金額確認')
   end
 end

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -51,8 +51,7 @@ class ReservationMailer < ApplicationMailer
     @reservation = reservation
     mail(to: @reservation.user.email, subject: 'nomini店舗予約詳細')
   end
-
-<<<<<<< HEAD
+  
   def update_reservation_to_nomini_from_shop(reservation)
     @reservation = reservation
     mail(to: @reservation.user.email, subject: '店舗が予約変更を受理しました')

--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -51,7 +51,7 @@ class ReservationMailer < ApplicationMailer
     @reservation = reservation
     mail(to: @reservation.user.email, subject: 'nomini店舗予約詳細')
   end
-  
+
   def update_reservation_to_nomini_from_shop(reservation)
     @reservation = reservation
     mail(to: @reservation.user.email, subject: '店舗が予約変更を受理しました')

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -32,4 +32,10 @@ class Reservation < ApplicationRecord
   def tax_included_price
     (sum_price * 1.08).floor # TODO: 消費税をどこかで定数化する
   end
+
+  def setting_payment(params=nil)
+    payment = build_reservation_payment(params)
+    payment.user = user
+    payment
+  end
 end

--- a/app/models/reservation_payment.rb
+++ b/app/models/reservation_payment.rb
@@ -20,9 +20,11 @@ class ReservationPayment < ApplicationRecord
   def liquidation(params)
     payjp_api = PayjpApi.new
     begin
-      token = PayjpApi.create_token(params)
-      update!(payjp_token_id: token.id, status: :paid)
-      payjp_api.create_charge(payjp_token_id, tax_included_amount)
+      ActiveRecord::Base.transaction do
+        token = PayjpApi.create_token(params)
+        update!(payjp_token_id: token.id, status: :paid)
+        payjp_api.create_charge(payjp_token_id, tax_included_amount)
+      end
     rescue => e
       errors[:base] << '支払いに失敗しました'
       return false

--- a/app/models/reservation_payment.rb
+++ b/app/models/reservation_payment.rb
@@ -2,9 +2,11 @@ class ReservationPayment < ApplicationRecord
   belongs_to :user
   belongs_to :reservation
 
-  validates :payjp_token_id, presence: true
+  validates :payjp_token_id, presence: true, unless: :requested?
   validates :currency, presence: true
   validates :amount, presence: true
+
+  enum status: { requested: 0, paid: 1 }
 
   def create_charge
     payjp_api = PayjpApi.new

--- a/app/views/mailers/payment_mailer/notification.html.erb
+++ b/app/views/mailers/payment_mailer/notification.html.erb
@@ -1,0 +1,30 @@
+<p><%= @payment.user.full_name_kana %>様</p>
+
+<p>
+  nominiをご利用いただきありがとうございます。<br>
+</p>
+
+<ul>
+  <li>
+    <h4>ご利用店舗</h4>
+    <p><%= @payment.reservation.shop.name %></p>
+    URL: <%= link_to shop_url(@payment.reservation.shop), shop_url(@payment.reservation.shop) %>
+  </li>
+  <li>
+    <h4>ご利用日時</h4>
+    <p>
+      <%= "#{l(@payment.reservation.use_date, format: :long)} #{l(@payment.reservation.use_time, format: :time_only)}" %>
+    </p>
+  </li>
+  <li>
+    <h4>決済金額(税込)</h4>
+    <p><%= @payment.tax_included_amount %>円</p>
+  </li>
+  <li>
+    <h4>決済URL</h4>
+    <p><%= link_to reservation_payment_url(@payment), reservation_payment_url(@payment) %></p>
+    <p>※ 翌日までに確定されない場合、自動で決済いたしますので御了承下さい。</p>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/confirm_use_price_to_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/confirm_use_price_to_shop.html.erb
@@ -33,6 +33,10 @@
     <h4>金額</h4>
     <p><%= @reservation.tax_included_price %>円</p>
   </li>
+  <li>
+    <h4>以下、URLから金額の確定をよろしくお願いいたします</h4>
+    <p><%= link_to '金額確認画面へ', new_shop_page_reservation_payment_url(@reservation) %></p>
+  </li>
 </ul>
 
 このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/mailers/reservation_mailer/confirm_use_price_to_shop.html.erb
+++ b/app/views/mailers/reservation_mailer/confirm_use_price_to_shop.html.erb
@@ -1,0 +1,38 @@
+<p><%= @reservation.shop.name %> ご担当者様</p>
+
+<p>
+  ご利用金額確認をお願いいたします。
+</p>
+
+<ul>
+  <li>
+    <h4>カテゴリ</h4>
+    <p><%= @reservation.reservation_category.name %></p>
+  </li>
+  <li>
+    <h4>予約者名</h4>
+    <p>
+      <%= @reservation.user.full_name_kana %><br>
+    </p>
+  </li>
+  <li>
+    <h4>登録者電話番号</h4>
+    <p>
+      <%= @reservation.user.phone_number %><br>
+    </p>
+  </li>
+  <li>
+    <h4>予約日時</h4>
+    <p><%= "#{l(@reservation.use_date, format: :long)} #{l(@reservation.use_time, format: :time_only)}" %></p>
+  </li>
+  <li>
+    <h4>予約人数</h4>
+    <p><%= @reservation.people_count %>人</p>
+  </li>
+  <li>
+    <h4>金額</h4>
+    <p><%= @reservation.tax_included_price %>円</p>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/app/views/reservation_payments/show.html.erb
+++ b/app/views/reservation_payments/show.html.erb
@@ -1,0 +1,69 @@
+<div class="container bg-white mt-3 pb-2">
+  <h2 class="text-info py-3 m-0">決済情報</h2>
+  <!-- Main content -->
+  <div class="confirm-box">
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label">ご利用店舗</h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation_payment.reservation.shop.name %>
+        </p>
+      </div>
+    </div>
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label">ご利用日時</h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= "#{l(@reservation_payment.reservation.use_date, format: :long)} #{l(@reservation_payment.reservation.use_time, format: :time_only)}" %>
+        </p>
+      </div>
+    </div>
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label">決済金額(税込)</h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation_payment.tax_included_amount %> 円
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class=" p-3 border border-mated rounded mt-3">
+  <h3 class="shop-detail-title text-info text-center">カード情報入力</h3>
+  <ul class="reservation-chack text-danger">
+    <% @reservation_payment.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+  </ul>
+  <%= form_for(@reservation_payment) do |f| %>
+    <span class="charge-errors"></span>
+    <div class="field form-group text-center">
+      <input type="text" class="form-control number" name="number" maxlength="16" placeholder="カード番号">
+    </div>
+
+    <div class="field form-group">
+      <div class="row">
+        <div class="col-md-3">
+          <input type="text" class="form-control exp_month" name="exp_month" maxlength="2" placeholder="月">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control exp_year" name="exp_year" maxlength="4" placeholder="年">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control cvc" name="cvc" maxlength="3" placeholder="CVC">
+        </div>
+      </div>
+    </div>
+
+    <div class="actions form-group text-center">
+      <%= f.submit '決済', class: "btn btn-danger" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shop_page/payments/new.html.erb
+++ b/app/views/shop_page/payments/new.html.erb
@@ -1,0 +1,63 @@
+<div class="main-area container bg-white mt-3 pb-3">
+  <h2 class="text-info text-center page-heading mb-4 mt-4">予約情報入力</h2>
+  <div class="confirm-box">
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label">お客様のお名前</h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation_payment.reservation.user.full_name_kana %>様
+        </p>
+      </div>
+    </div>
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:reservation_category) %></h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation_payment.reservation.reservation_category&.name %>
+        </p>
+      </div>
+    </div>
+
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label">料金</h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation_payment.reservation.output_price %>円
+        </p>
+      </div>
+    </div>
+
+    <div class="row confirm-list">
+      <div class="col-md-3">
+        <h3 class="confirm-label"><%= Reservation.human_attribute_name(:people_count) %></h3>
+      </div>
+      <div class="col-md-9">
+        <p class="confirm-value">
+          <%= @reservation_payment.reservation.people_count %>人
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <ul class="reservation-chack text-danger text-center list-unstyled">
+    <% @reservation_payment.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+    <% end %>
+  </ul>
+  <%= form_with model: [:shop_page, @reservation_payment], local: true do |form| %>
+    <div class="field form-group row center-form">
+      <%= form.label '利用金額(税抜き) 修正がない場合はそのまま確定ボタンを押してください', class: "col-sm-4 signup-label m-0" %>
+      <%= form.text_field :amount, placeholder: '金額を入力してください', value: @reservation_payment.reservation.sum_price, class: "col-sm-8 form-control" %>
+    </div>
+
+    <div class="box-footer text-center">
+      <%= form.submit '確定', class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shop_page/reservations/price.html.erb
+++ b/app/views/shop_page/reservations/price.html.erb
@@ -1,0 +1,43 @@
+<div class="main-area container bg-white mt-3 pb-3">
+  <h2 class="text-info text-center page-heading mb-4 mt-4">予約情報入力</h2>
+  <ul class="reservation-chack text-danger text-center list-unstyled">
+    <% @reservation.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+  </ul>
+  <%= form_with model: @reservation, url: confirm_shop_page_reservations_url, local: true do |form| %>
+    <div class="field form-group row center-form">
+      <%= form.label 'お客様の電話番号', class: "col-sm-4 signup-label m-0" %>
+      <%= form.text_field :phone_number, placeholder: 'ハイフンなしで入力してください。', class: "col-sm-8 form-control" %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :reservation_category_id, class: "col-sm-4 signup-label m-0" %>
+      <%= form.select :reservation_category_id, current_shop.valid_categories_list, {label: "予約カテゴリ"}, { class: "col-sm-8 form-control" } %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :people_count, class: "col-sm-4 signup-label m-0" %>
+      <%= form.select :people_count, (1..30).map {|num| num.to_s + "名"}, {}, { class: "col-sm-8 form-control" } %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :use_date, class: "col-sm-4 signup-label m-0" %>
+      <%= form.text_field :use_date, id: "datetimepicker", class: "col-sm-8 form-control" %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :use_time, class: "col-sm-4 signup-label m-0" %>
+      <%= form.time_select :use_time, { minute_step: 10 }, { class: "col-sm-3 form-control" } %>
+    </div>
+
+    <div class="field form-group row center-form">
+      <%= form.label :message, class: "col-sm-4 signup-label m-0" %>
+      <%= form.text_area :message, class: "col-sm-8 form-control" %>
+    </div>
+
+    <div class="box-footer text-center">
+      <%= form.submit '予約情報を確認する', class: "btn btn-info" %>
+    </div>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module NominiReserve
     config.time_zone = 'Asia/Tokyo'
     config.i18n.default_locale = :ja
 
+    config.paths.add 'lib', eager_load: true
+
     config.generators do |g|
       g.test_framework       :rspec, view_specs: false, helper_specs: false, fixture: true
       g.helper               false

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,7 +1,10 @@
 set :stage, :production
 set :rails_env, 'production'
 set :branch, ENV['BRANCH'] || 'master'
+set :whenever_roles, :batch
+set :whenever_environment, :production
 
 role :app, %w{ app@app1.nomini.jp }
 role :web, %w{ app@app1.nomini.jp }
 role :db,  %w{ app@app1.nomini.jp }
+role :batch, %w{ app@app1.nomini.jp }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  namespace :shop_page do
-    get 'payments/new'
-  end
-
-  get 'exchanges/new'
-
   root 'reservations#index'
 
   namespace :shop_page do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
   resources :exchanges, only: [:new, :create, :show] do
     patch :reapply, on: :member
   end
+  resources :reservation_payments, only: [:show, :update]
 
   devise_for :admins,
     path: 'admin',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,18 @@
 Rails.application.routes.draw do
+  namespace :shop_page do
+    get 'payments/new'
+  end
+
   get 'exchanges/new'
 
   root 'reservations#index'
 
   namespace :shop_page do
     root 'reservations#index'
-    resources :reservations do
+    resources :reservations, shallow: true do
       post :confirm, on: :collection
       patch :cancel, on: :member
+      resources :payments, only: [:new, :create]
     end
   end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,20 +1,6 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
+set :output, 'log/cron.log'
 
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
-
-# Learn more: http://github.com/javan/whenever
+# 金額確認メール
+every 1.day, at: '0:30 am' do
+  runner "Batches::PaymentConfirmBatch.exec"
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,5 @@
 mail:
   from: noreply@nomini.jp
   to: admin@nomini.jp
+
+consumption_tax: 1.08

--- a/db/migrate/20171120153143_change_null_true_to_reservation_payments.rb
+++ b/db/migrate/20171120153143_change_null_true_to_reservation_payments.rb
@@ -1,0 +1,5 @@
+class ChangeNullTrueToReservationPayments < ActiveRecord::Migration[5.1]
+  def change
+    change_column :reservation_payments, :payjp_token_id, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171111060202) do
+ActiveRecord::Schema.define(version: 20171120153143) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20171111060202) do
   create_table "reservation_payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "user_id"
     t.bigint "reservation_id"
-    t.string "payjp_token_id", null: false
+    t.string "payjp_token_id"
     t.string "currency", default: "jpy", null: false
     t.integer "amount", default: 0, null: false
     t.integer "status", default: 0, null: false

--- a/lib/batches/base.rb
+++ b/lib/batches/base.rb
@@ -1,0 +1,23 @@
+require 'logger'
+
+class Batches::Base
+  @@is_dryrun = false
+
+  class << self
+    def logger
+      @@logger ||= Logger.new(
+        dryrun? ? STDOUT : File.join(Rails.root, 'log', "#{Rails.env.underscore}.log")
+      )
+    end
+
+    def dryrun(*args)
+      @@is_dryrun = true
+      logger.level = Logger::DEBUG
+      exec(*args)
+    end
+
+    def dryrun?
+      @@is_dryrun
+    end
+  end
+end

--- a/lib/batches/payment_confirm_batch.rb
+++ b/lib/batches/payment_confirm_batch.rb
@@ -1,0 +1,17 @@
+class Batches::PaymentConfirmBatch < Batches::Base
+  def self.exec
+    logger.info('start')
+    logger.debug('show only in dryrun mode.')
+    unless dryrun?
+      send_confirm_price_mail
+    end
+    logger.info('finish.')
+  end
+
+  def self.send_confirm_price_mail
+    Reservation.where(use_date: Date.yesterday).find_each do |reservation|
+      ReservationMailer.confirm_use_price_to_shop(reservation).deliver_now
+      logger.info("Send_confirm_price,#{reservation.use_date},#{reservation.id},#{reservation.shop.email},#{reservation.tax_included_price},#{reservation.people_count}")
+    end
+  end
+end

--- a/spec/controllers/reservation_payments_controller_spec.rb
+++ b/spec/controllers/reservation_payments_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ReservationPaymentsController, type: :controller do
+
+  describe "GET #show" do
+    it "returns http success" do
+      get :show
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/controllers/shop_page/payments_controller_spec.rb
+++ b/spec/controllers/shop_page/payments_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ShopPage::PaymentsController, type: :controller do
+
+  describe "GET #new" do
+    it "returns http success" do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/mailers/payment_spec.rb
+++ b/spec/mailers/payment_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe PaymentMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/payment_preview.rb
+++ b/spec/mailers/previews/payment_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/payment
+class PaymentPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
## 概要
店舗利用後から決済までの流れを作成する

## 対応内容
* whenever導入
* 利用日の翌0:30にバッチが回るようスケジューラを設定
* 利用金額確認メールを店舗に送信するバッチを作成
* 利用金額画面を作成
* 利用者が決済できる画面を作成する

## メモ
* 決済期限をreservation_paymentに持たせるべきかも
* 強制決済機能も別issueで作る