### PR TITLE
支払い期限日超過の強制決済

### DIFF
--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -6,4 +6,9 @@ class PaymentMailer < ApplicationMailer
     @payment = payment
     mail(to: @payment.user.email, subject: "【nomini】#{@payment.reservation.shop.name}ご利用の決済について")
   end
+
+  def force_paid(payment)
+    @payment = payment
+    mail(to: @payment.user.email, subject: "【nomini】#{@payment.reservation.shop.name}ご利用の決済が完了しました")
+  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -36,6 +36,7 @@ class Reservation < ApplicationRecord
   def setting_payment(params=nil)
     payment = build_reservation_payment(params)
     payment.user = user
+    payment.limited_on = Date.tomorrow # TODO: 決済日付が決定次第変更可能性あり
     payment
   end
 end

--- a/app/models/reservation_payment.rb
+++ b/app/models/reservation_payment.rb
@@ -3,15 +3,11 @@ class ReservationPayment < ApplicationRecord
   belongs_to :reservation
 
   validates :payjp_token_id, presence: true, unless: :requested?
+  validates :limited_on, presence: true
   validates :currency, presence: true
   validates :amount, presence: true
 
-  enum status: { requested: 0, paid: 1 }
-
-  def create_charge
-    payjp_api = PayjpApi.new
-    payjp_api.create_charge(payjp_token_id, amount)
-  end
+  enum status: { requested: 0, paid: 1, force_paid: 2, failed: 3 }
 
   def tax_included_amount
     (amount * Settings.consumption_tax).to_i

--- a/app/views/mailers/payment_mailer/force_paid.html.erb
+++ b/app/views/mailers/payment_mailer/force_paid.html.erb
@@ -1,0 +1,26 @@
+<p><%= @payment.user.full_name_kana %>様</p>
+
+<p>
+  nominiをご利用いただきありがとうございます。<br>
+  下記、決済を行いましたのでご確認ください。
+</p>
+
+<ul>
+  <li>
+    <h4>ご利用店舗</h4>
+    <p><%= @payment.reservation.shop.name %></p>
+    URL: <%= link_to shop_url(@payment.reservation.shop), shop_url(@payment.reservation.shop) %>
+  </li>
+  <li>
+    <h4>ご利用日時</h4>
+    <p>
+      <%= "#{l(@payment.reservation.use_date, format: :long)} #{l(@payment.reservation.use_time, format: :time_only)}" %>
+    </p>
+  </li>
+  <li>
+    <h4>決済金額(税込)</h4>
+    <p><%= @payment.tax_included_amount %>円</p>
+  </li>
+</ul>
+
+このメールは配信専用です。返信はできませんので御了承ください。

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -130,6 +130,7 @@ ja:
         amount: 支払い額
         currency: ISOコード
         status: ステータス
+        limited_on: 決済期限日付
         created_at: 登録日時
         updated_at: 更新日時
       introduction:
@@ -176,3 +177,9 @@ ja:
         num: 数値
         str: 文字列
         selection: 選択肢
+    reservation_payment:
+      status:
+        requested: 決済待ち
+        paid: 決済完了
+        force_paid: 強制決済
+        failed: 決済失敗

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,3 +4,8 @@ set :output, 'log/cron.log'
 every 1.day, at: '0:30 am' do
   runner "Batches::PaymentConfirmBatch.exec"
 end
+
+# 強制決済
+every 1.day, at: '1:00 am' do
+  runner "Batches::ForcePaymentBatch.exec"
+end

--- a/db/migrate/20171125094547_add_limited_on_to_reservation_payments.rb
+++ b/db/migrate/20171125094547_add_limited_on_to_reservation_payments.rb
@@ -1,0 +1,5 @@
+class AddLimitedOnToReservationPayments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :reservation_payments, :limited_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120153143) do
+ActiveRecord::Schema.define(version: 20171125094547) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 20171120153143) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "limited_on"
     t.index ["reservation_id"], name: "index_reservation_payments_on_reservation_id"
     t.index ["user_id"], name: "index_reservation_payments_on_user_id"
   end

--- a/lib/batches/force_payment_batch.rb
+++ b/lib/batches/force_payment_batch.rb
@@ -1,0 +1,18 @@
+class Batches::ForcePaymentBatch < Batches::Base
+  def self.exec
+    logger.info('Force payment batch start.')
+    logger.debug('show only in dryrun mode.')
+    unless dryrun?
+      force_payment
+    end
+    logger.info('Force payment batch finish.')
+  end
+
+  def self.force_payment
+    ReservationPayment.requested.where(limited_on: Date.yesterday).find_each do |payment|
+      payjp_token = payment.user&.subscription&.payjp_token
+      payment.force_liquidation(payjp_token)
+      logger.info("Force_payment,#{payment.user_id},#{payment.reservation_id},#{payment.tax_included_amount},#{payment.status}")
+    end
+  end
+end

--- a/lib/batches/force_payment_batch.rb
+++ b/lib/batches/force_payment_batch.rb
@@ -12,6 +12,9 @@ class Batches::ForcePaymentBatch < Batches::Base
     ReservationPayment.requested.where(limited_on: Date.yesterday).find_each do |payment|
       payjp_token = payment.user&.subscription&.payjp_token
       payment.force_liquidation(payjp_token)
+      if payment.force_paid?
+        PaymentMailer.force_paid(payment).deliver_now
+      end
       logger.info("Force_payment,#{payment.user_id},#{payment.reservation_id},#{payment.tax_included_amount},#{payment.status}")
     end
   end

--- a/lib/batches/payment_confirm_batch.rb
+++ b/lib/batches/payment_confirm_batch.rb
@@ -1,11 +1,11 @@
 class Batches::PaymentConfirmBatch < Batches::Base
   def self.exec
-    logger.info('start')
+    logger.info('Payment confirm batch start')
     logger.debug('show only in dryrun mode.')
     unless dryrun?
       send_confirm_price_mail
     end
-    logger.info('finish.')
+    logger.info('Payment confirm batch finish.')
   end
 
   def self.send_confirm_price_mail


### PR DESCRIPTION
#93 

## 概要
強制決済バッチを作成

## 対応内容
* reservation_pamentに期限日カラムを追加
* reservation_paymentに強制決済、決済失敗のレコードを追加
* 強制決済バッチ、スケジューラの設定
* 強制決済お知らせメール送信作成