### PR TITLE
決済時に登録済みカードを利用できるよう機能追加

### DIFF
--- a/app/controllers/reservation_payments_controller.rb
+++ b/app/controllers/reservation_payments_controller.rb
@@ -13,6 +13,14 @@ class ReservationPaymentsController < ApplicationController
     end
   end
 
+  def registed_card
+    if @reservation_payment.registed_card_liquidation(current_user)
+      redirect_to mypage_url, notice: '決済を完了しました'
+    else
+      render :show
+    end
+  end
+
   private
 
   def set_reservation_payment

--- a/app/models/payjp_api.rb
+++ b/app/models/payjp_api.rb
@@ -26,6 +26,14 @@ class PayjpApi
     )
   end
 
+  def create_charge_by_registed_card(customer, amount, currency='jpy')
+    Payjp::Charge.create(
+      amount: amount,
+      customer: customer,
+      currency: currency,
+    )
+  end
+
   def cancel_subscription(subscription_id)
     subscription = Payjp::Subscription.retrieve(subscription_id)
     subscription.pause

--- a/app/models/reservation_payment.rb
+++ b/app/models/reservation_payment.rb
@@ -2,10 +2,10 @@ class ReservationPayment < ApplicationRecord
   belongs_to :user
   belongs_to :reservation
 
-  validates :payjp_token_id, presence: true, unless: :requested?
   validates :limited_on, presence: true
   validates :currency, presence: true
   validates :amount, presence: true
+  validate :valid_payjp_info, unless: :requested?
 
   enum status: { requested: 0, paid: 1, force_paid: 2, failed: 3 }
 
@@ -41,5 +41,27 @@ class ReservationPayment < ApplicationRecord
       return false
     end
     true
+  end
+
+  def registed_card_liquidation(user)
+    payjp_api = PayjpApi.new
+    begin
+      ActiveRecord::Base.transaction do
+        update!(customer_id: user.subscription.customer_id, status: :paid)
+        payjp_api.create_charge_by_registed_card(customer_id, tax_included_amount)
+      end
+    rescue => e
+      errors[:base] << '支払いに失敗しました'
+      return false
+    end
+    true
+  end
+
+  private
+
+  def valid_payjp_info
+    if payjp_token_id.blank? && customer_id.blank?
+      errors[:base] << '支払い情報に誤りがあります'
+    end
   end
 end

--- a/app/views/admin/reservation_payments/index.html.erb
+++ b/app/views/admin/reservation_payments/index.html.erb
@@ -20,7 +20,7 @@
           <% @reservation_payments.each do |reservation_payment| %>
             <tr>
               <td><%= reservation_payment.id %></td>
-              <td><%= reservation_payment.status %></td>
+              <td><%= reservation_payment.status_i18n %></td>
               <td><%= reservation_payment.user.full_name_kana %></td>
               <td><%= reservation_payment.payjp_token_id %></td>
               <td><%= reservation_payment.amount %> 円</td>

--- a/app/views/admin/reservation_payments/show.html.erb
+++ b/app/views/admin/reservation_payments/show.html.erb
@@ -40,6 +40,13 @@
     </div>
 
     <div class="box-header with-border">
+      <h3 class="box-title"><%= ReservationPayment.human_attribute_name(:customer_id) %></h3>
+    </div>
+    <div class="box-body">
+      <%= @reservation_payment.customer_id %>
+    </div>
+
+    <div class="box-header with-border">
       <h3 class="box-title"><%= ReservationPayment.human_attribute_name(:amount) %></h3>
     </div>
     <div class="box-body">

--- a/app/views/reservation_payments/show.html.erb
+++ b/app/views/reservation_payments/show.html.erb
@@ -43,7 +43,8 @@
       </ul>
 
       <div class="mb-3">
-        <%= link_to '登録済みカードで決済する', registed_card_reservation_payment_path(@reservation_payment), method: :patch, class: 'btn btn-primary btn-block' %>
+        <%= link_to '登録済みカードで決済する', registed_card_reservation_payment_path(@reservation_payment),
+                    method: :patch, class: 'btn btn-primary btn-block', data: { confirm: '登録しているカード決済します。よろしいでしょうか。' } %>
       </div>
 
       <%= form_for(@reservation_payment) do |f| %>

--- a/app/views/reservation_payments/show.html.erb
+++ b/app/views/reservation_payments/show.html.erb
@@ -41,6 +41,11 @@
           <li><%= msg %></li>
         <% end %>
       </ul>
+
+      <div class="mb-3">
+        <%= link_to '登録済みカードで決済する', registed_card_reservation_payment_path(@reservation_payment), method: :patch, class: 'btn btn-primary btn-block' %>
+      </div>
+
       <%= form_for(@reservation_payment) do |f| %>
         <span class="charge-errors"></span>
         <div class="field form-group text-center">

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -127,6 +127,7 @@ ja:
         reservation_id: 予約ID
         user_name: ユーザー名
         payjp_token_id: トークンID(payjp)
+        customer_id: 顧客ID(payjp)
         amount: 支払い額
         currency: ISOコード
         status: ステータス

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,9 @@ Rails.application.routes.draw do
   resources :exchanges, only: [:new, :create, :show] do
     patch :reapply, on: :member
   end
-  resources :reservation_payments, only: [:show, :update]
+  resources :reservation_payments, only: [:show, :update] do
+    patch :registed_card, on: :member
+  end
 
   devise_for :admins,
     path: 'admin',

--- a/db/migrate/20171130151342_add_customer_id_to_reservation_payments.rb
+++ b/db/migrate/20171130151342_add_customer_id_to_reservation_payments.rb
@@ -1,0 +1,5 @@
+class AddCustomerIdToReservationPayments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :reservation_payments, :customer_id, :string, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171125094547) do
+ActiveRecord::Schema.define(version: 20171130151342) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20171125094547) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "limited_on"
+    t.string "customer_id"
     t.index ["reservation_id"], name: "index_reservation_payments_on_reservation_id"
     t.index ["user_id"], name: "index_reservation_payments_on_user_id"
   end


### PR DESCRIPTION
## 概要
決済時に登録済みカードで決済できるボタンを設置

## 対応内容
* reservation_paymentsにcustomer_idカラムを追加(登録済みカードはtokenではなく顧客IDで行うっぽいので)
* バリデーション微修正
* 画面にボタン追加

![2017-12-01 0 35 08](https://user-images.githubusercontent.com/14311071/33439015-c135cb1c-d62f-11e7-9111-b23e9639b897.png)


## その他
* reservation_paymentのメソッドがほぼ似たような感じなのでリファクタリングできそう感がすごい。。。