### PR TITLE
店舗の地域情報追加&店舗名表示制御

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -179,6 +179,7 @@ body {
 
 .shop-detail{
   white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 .image-wrap{
@@ -347,4 +348,9 @@ body {
       font-weight: bold;
     }
   }
+}
+
+.area-info{
+  font-size: 0.8rem;
+  font-weight: bold;
 }

--- a/app/controllers/admin/shops_controller.rb
+++ b/app/controllers/admin/shops_controller.rb
@@ -53,7 +53,7 @@ class Admin::ShopsController < AdminController
 
   def shop_params
     params.fetch(:shop, {}).permit(
-      :email, :password, :password_confirmation, :name, :description, :prefecture_id, :city_code, :image, :image_cache,
+      :email, :password, :password_confirmation, :name, :description, :prefecture_id, :city_code, :area_text, :address_detail, :image, :image_cache,
       :service_time, :price, :phone_number, shop_usages_attributes: [:id, :reservation_category_id, :price]
     )
   end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -35,7 +35,7 @@ class ShopsController < ApplicationController
 
   def shop_params
     params.fetch(:shop, {}).permit(
-       :email, :name, :image, :image_cache, :phone_number, :description, :prefecture_id, :city_code, :service_time, :price,
+       :email, :name, :image, :image_cache, :phone_number, :description, :prefecture_id, :city_code, :area_text, :address_detail, :service_time, :price,
        shop_usages_attributes: [:id, :reservation_category_id, :price]
     )
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,12 @@ module ApplicationHelper
     city ||= City.initial_display
     options_for_select(city.same_prefecture_cities.map{|city| [city.name, city.city_code]}, city.city_code)
   end
+
+  # 店舗名の表示制御
+  def shop_name_text(shop)
+    if current_user.subscription.present?
+      shop.name
+    end
+  end
+
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -55,4 +55,8 @@ class Shop < ApplicationRecord
     name
   end
 
+  def address_text
+    "#{prefecture.name} #{city.name} #{area_text} #{address_detail}"
+  end
+
 end

--- a/app/views/admin/shops/_form.html.erb
+++ b/app/views/admin/shops/_form.html.erb
@@ -8,6 +8,8 @@
         <%= form.text_field :name %>
         <%= form.collection_select :prefecture_id, Prefecture.all, :id, :name, selected: shop.prefecture_id %>
         <%= form.select :city_code, city_list(shop.city), selected: shop.city %>
+        <%= form.text_field :area_text, placeholder: '九段南' %>
+        <%= form.text_field :address_detail, placeholder: '○丁目○-○ ○○ビル 5F' %>
         <%= form.text_area :description %>
         <%= form.file_field :image %>
         <%= form.hidden_field :image_cache %>

--- a/app/views/admin/shops/show.html.erb
+++ b/app/views/admin/shops/show.html.erb
@@ -38,6 +38,8 @@
     <div class="box-body">
       <span><%= @shop.prefecture&.name %></span>
       <span><%= @shop.city&.name %></span>
+      <span><%= @shop.area_text %></span>
+      <span><%= @shop.address_detail %></span>
     </div>
 
     <div class="box-header with-border">

--- a/app/views/shops/edit.html.erb
+++ b/app/views/shops/edit.html.erb
@@ -18,6 +18,16 @@
     </div>
 
     <div class="field form-group row signup-form">
+      <%= form.label :area_text, class: "col-sm-3 signup-label" %><br />
+      <%= form.text_field :area_text, placeholder: '九段南', class: "col-sm-9 form-control" %>
+    </div>
+
+    <div class="field form-group row signup-form">
+      <%= form.label :address_detail, class: "col-sm-3 signup-label" %><br />
+      <%= form.text_field :address_detail, placeholder: '○丁目○-○ ○○ビル 5F', class: "col-sm-9 form-control" %>
+    </div>
+
+    <div class="field form-group row signup-form">
       <%= form.label :image, class: "col-sm-3 signup-label" %><br />
       <%= form.file_field :image, class: "col-sm-9 form-control" %>
       <%= form.hidden_field :image_cache %>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -14,9 +14,13 @@
 
       <div class="col-md-9 pt-2" >
         <div class="row">
-          <h3 class="shop-name col-md-10 pl-0">
-            <%= shop.name %>
-          </h3>
+          <div class="shop-name col-md-10 pl-0">
+            <h3 class="area-info text-info">
+              <span><%= shop.city.name %></span>
+              <span><%= shop.area_text %></span>
+            </h3>
+            <h3><%= shop_name_text(shop) %></h3>
+          </div>
           <div class="col-md-2">
             <%= link_to '詳細を見る', shop_path(shop), class: "float-md-right btn btn-info shop-detail-btn" %>
           </div>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container bg-white mt-3 pb-2 main-area">
-  <h2 class="shop-name text-info py-3 m-0"><%= @shop.name %></h2>
+  <h2 class="shop-name text-info py-3 m-0"><%= shop_name_text(@shop) %></h2>
   <div class="row">
     <div class="col-md-8">
       <%= image_tag @shop.image, size: '500x500', class: "d-flex align-self-center shop-show-image"%>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -26,10 +26,17 @@
           <% end %>
         <% end %>
       </div>
-      <h3 class="shop-detail-title text-info">電話番号</h3>
-      <div class="ml-2 mb-3">
-        <%= @shop.phone_number %>
-      </div>
+      <% if current_user.subscription.present? %>
+        <h3 class="shop-detail-title text-info">電話番号</h3>
+        <div class="ml-2 mb-3">
+          <%= @shop.phone_number %>
+        </div>
+
+        <h3 class="shop-detail-title text-info">住所</h3>
+        <div class="ml-2 mb-3">
+          <%= @shop.address_text %>
+        </div>
+      <% end %>
     </div>
   </div>
   <div class="row">

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -14,6 +14,8 @@ ja:
         remember_me: ログインしたままにする
         prefecture_id: 都道府県
         city_code: 市区町村
+        area_text: エリア
+        address_detail: 住所詳細
         created_at: 登録日時
         updated_at: 更新日時
       reservation_category:

--- a/db/migrate/20171203091856_add_address_info_to_shops.rb
+++ b/db/migrate/20171203091856_add_address_info_to_shops.rb
@@ -1,0 +1,6 @@
+class AddAddressInfoToShops < ActiveRecord::Migration[5.1]
+  def change
+    add_column :shops, :area_text, :text
+    add_column :shops, :address_detail, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171203080220) do
+ActiveRecord::Schema.define(version: 20171203091856) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
@@ -201,6 +201,8 @@ ActiveRecord::Schema.define(version: 20171203080220) do
     t.string "unconfirmed_email"
     t.string "city_code"
     t.integer "prefecture_id"
+    t.text "area_text"
+    t.text "address_detail"
     t.index ["email"], name: "index_shops_on_email", unique: true
     t.index ["reset_password_token"], name: "index_shops_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# 概要
- 非課金ユーザーに店舗名を隠し、エリアを表示する

# 作業内容
- 店舗テーブルにカラム追加
- 管理画面/店舗用画面からの追加更新
- 非課金ユーザーの場合、店舗一覧において、店舗名を表示せず、市区町村とエリアのみ表示する
- 念のため、詳細画面にも制御を追加