### PR TITLE
定期課金バッチ作成

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,9 @@
 class Subscription < ApplicationRecord
   belongs_to :user
 
+  USAGE_THRESHOLD = 20_000
+  MONTHLY_AMOUNT = 980
+
   enum status: { cancel: 0, trial: 1, active: 2, examption: 3 }
 
   validates :customer_id, presence: true
@@ -14,6 +17,24 @@ class Subscription < ApplicationRecord
     payjp_api = PayjpApi.new
     self.customer_id = payjp_api.create_customer(token).id
     self.save
+  end
+
+  def reset_configure
+    user.update!(monthly_usage_amount: 0)
+    update!(next_charge_on: 1.months.since)
+  end
+
+  def included_trail_term?
+    next_charge_on < trail_finished_on
+  end
+
+  def achieve_usage_threshold?
+    user.monthly_usage_amount >= USAGE_THRESHOLD
+  end
+
+  def payment_monthly_amount
+    payjp_api = PayjpApi.new
+    payjp_api.create_charge_by_registed_card(customer_id, MONTHLY_AMOUNT)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,4 +59,9 @@ class User < ApplicationRecord
   def full_name_kana
     "#{l_name_kana} #{f_name_kana}"
   end
+
+  def add_monthly_usage_amount!(amount)
+    sum = monthly_usage_amount + amount
+    update!(monthly_usage_amount: sum)
+  end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,3 +9,8 @@ end
 every 1.day, at: '1:00 am' do
   runner "Batches::ForcePaymentBatch.exec"
 end
+
+# 定期課金
+every 1.day, at: '3:00 am' do
+  runner "Batches::SubscriptionBatch.exec"
+end

--- a/lib/batches/subscription_batch.rb
+++ b/lib/batches/subscription_batch.rb
@@ -12,35 +12,35 @@ class Batches::SubscriptionBatch < Batches::Base
 
   def self.payment_subscription(subscription)
     begin
-    ActiveRecord::Base.transaction do
-      # トライアル期間中の処理
-      if subscription.trail_finished_on < subscription.next_charge_on
-        use_price = subscription.user.monthly_usage_amount
+      ActiveRecord::Base.transaction do
+        # トライアル期間中の処理
+        if subscription.next_charge_on < subscription.trail_finished_on
+          use_price = subscription.user.monthly_usage_amount
+          subscription.user.update!(monthly_usage_amount: 0)
+          subscription.update!(next_charge_on: 1.months.since)
+          trail_log(subscription, use_price)
+          return
+        end
+
+        # トライアル終了
+        if subscription.trial?
+          subscription.active!
+          finish_trail_log(subscription)
+        end
+
+        # 課金処理
+        if subscription.user.monthly_usage_amount < 20_000
+          payjp_api = PayjpApi.new
+          payjp_api.create_charge_by_registed_card(subscription.customer_id, 980)
+          payment_log(subscription)
+        else
+          examption_log(subscription)
+        end
+
+        # 翌月の課金日設定、利用金額リセット
         subscription.user.update!(monthly_usage_amount: 0)
         subscription.update!(next_charge_on: 1.months.since)
-        trail_log(subscription, use_price)
-        return
       end
-
-      # トライアル終了
-      if subscription.trail?
-        subscription.active!
-        finish_trail_log(subscription)
-      end
-
-      # 課金処理
-      if subscription.user.monthly_usage_amount < 20_000
-        payjp_api = PayjpApi.new
-        payjp_api.create_charge_by_registed_card(subscription.customer_id, 980)
-        payment_log(subscription)
-      else
-        examption_log(subscription)
-      end
-
-      # 翌月の課金日設定、利用金額リセット
-      subscription.user.update!(monthly_usage_amount: 0)
-      subscription.update!(next_charge_on: 1.months.since)
-    end
     rescue => e
       subscription_fail_log(subscription)
     end

--- a/lib/batches/subscription_batch.rb
+++ b/lib/batches/subscription_batch.rb
@@ -3,7 +3,7 @@ class Batches::SubscriptionBatch < Batches::Base
     logger.info('Payment confirm batch start')
     logger.debug('show only in dryrun mode.')
     unless dryrun?
-      Subscription.where(next_charge_on: Date.today).find_each do |subscription|
+      Subscription.includes(:user).where(next_charge_on: Date.today).find_each do |subscription|
         payment_subscription(subscription)
       end
     end
@@ -13,39 +13,49 @@ class Batches::SubscriptionBatch < Batches::Base
   def self.payment_subscription(subscription)
     begin
       ActiveRecord::Base.transaction do
-        # トライアル期間中の処理
-        if subscription.next_charge_on < subscription.trail_finished_on
-          use_price = subscription.user.monthly_usage_amount
-          subscription.user.update!(monthly_usage_amount: 0)
-          subscription.update!(next_charge_on: 1.months.since)
-          trail_log(subscription, use_price)
+        if include_trial?(subscription)
           return
         end
-
-        # トライアル終了
-        if subscription.trial?
-          subscription.active!
-          finish_trail_log(subscription)
-        end
-
-        # 課金処理
-        if subscription.user.monthly_usage_amount < 20_000
-          payjp_api = PayjpApi.new
-          payjp_api.create_charge_by_registed_card(subscription.customer_id, 980)
-          payment_log(subscription)
-        else
-          examption_log(subscription)
-        end
-
-        # 翌月の課金日設定、利用金額リセット
-        subscription.user.update!(monthly_usage_amount: 0)
-        subscription.update!(next_charge_on: 1.months.since)
+        finish_trial(subscription)
+        execute_payment(subscription)
+        subscription.reset_configure
       end
     rescue => e
       subscription_fail_log(subscription)
     end
   end
 
+  # トライアル期間中の処理
+  def self.include_trial?(subscription)
+    if subscription.included_trail_term?
+      use_price = subscription.user.monthly_usage_amount
+      subscription.reset_configure
+      trail_log(subscription, use_price)
+      return true
+    end
+    false
+  end
+
+  # トライアル終了
+  def self.finish_trial(subscription)
+    if subscription.trial?
+      subscription.active!
+      finish_trail_log(subscription)
+    end
+  end
+
+  # 課金処理
+  def self.execute_payment(subscription)
+    unless subscription.achieve_usage_threshold?
+      subscription.payment_monthly_amount
+      payment_log(subscription)
+    else
+      examption_log(subscription)
+    end
+  end
+
+
+  # Logger
   def self.trail_log(subscription, use_price)
     logger.info("Trail_examption,#{subscription.id},#{subscription.user_id},#{Date.today},#{use_price}")
   end

--- a/lib/batches/subscription_batch.rb
+++ b/lib/batches/subscription_batch.rb
@@ -1,0 +1,68 @@
+class Batches::SubscriptionBatch < Batches::Base
+  def self.exec
+    logger.info('Payment confirm batch start')
+    logger.debug('show only in dryrun mode.')
+    unless dryrun?
+      Subscription.where(next_charge_on: Date.today).find_each do |subscription|
+        payment_subscription(subscription)
+      end
+    end
+    logger.info('Payment confirm batch finish.')
+  end
+
+  def self.payment_subscription(subscription)
+    begin
+    ActiveRecord::Base.transaction do
+      # トライアル期間中の処理
+      if subscription.trail_finished_on < subscription.next_charge_on
+        use_price = subscription.user.monthly_usage_amount
+        subscription.user.update!(monthly_usage_amount: 0)
+        subscription.update!(next_charge_on: 1.months.since)
+        trail_log(subscription, use_price)
+        return
+      end
+
+      # トライアル終了
+      if subscription.trail?
+        subscription.active!
+        finish_trail_log(subscription)
+      end
+
+      # 課金処理
+      if subscription.user.monthly_usage_amount < 20_000
+        payjp_api = PayjpApi.new
+        payjp_api.create_charge_by_registed_card(subscription.customer_id, 980)
+        payment_log(subscription)
+      else
+        examption_log(subscription)
+      end
+
+      # 翌月の課金日設定、利用金額リセット
+      subscription.user.update!(monthly_usage_amount: 0)
+      subscription.update!(next_charge_on: 1.months.since)
+    end
+    rescue => e
+      subscription_fail_log(subscription)
+    end
+  end
+
+  def self.trail_log(subscription, use_price)
+    logger.info("Trail_examption,#{subscription.id},#{subscription.user_id},#{Date.today},#{use_price}")
+  end
+
+  def self.finish_trail_log(subscription)
+    logger.info("Finish_trail,#{subscription.id},#{subscription.user_id},#{Date.today}")
+  end
+
+  def self.payment_log(subscription)
+    logger.info("Payment_subscription,#{subscription.id},#{subscription.user_id},#{Date.today},#{subscription.user.monthly_usage_amount}")
+  end
+
+  def self.examption_log(subscription)
+    logger.info("Subscription_exempt,#{subscription.id},#{subscription.user_id},#{Date.today},#{subscription.user.monthly_usage_amount}")
+  end
+
+  def self.subscription_fail_log(subscription)
+    logger.info("Fail_subscription,#{subscription.id},#{subscription.user_id},#{Date.today},#{subscription.user.monthly_usage_amount}")
+  end
+end


### PR DESCRIPTION
## 概要
定期課金を行うバッチを作成

## バッチの処理概要
* トライアル期間判定
  * トライアル時は支払いを行わずログだけ吐く
* トライアル解除
* 月間の利用金額判定機能
  * 月間利用金額が20000未満の場合、課金
  * 20000以上の場合は課金免除
* 月間利用金額、次回課金日の更新
* 月間利用金額を加算する仕組みを作成する(決済時)