### PR TITLE
店舗一覧画面&パスワード再発行画面調整

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -77,6 +77,17 @@ a[href^="tel:"] {
 .password-remember{
   font-size: 0.8rem;
 }
+
+// パスワード再発行画面のタイトル文字
+@media (max-width: 767px) {
+  .password-forget-title{
+    font-size: 1.3rem;
+  }
+  .password-forget-guide{
+    font-size: 0.8rem;
+  }
+}
+
 // ログインしたままにする
 .remember-me{
   color: $main-purple;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -302,17 +302,12 @@ a[href^="tel:"] {
 
 .course-price{
   font-size: 0.8rem;
+  border-left: 2px solid $main-purple;
 }
 
 .shop-detail{
   white-space: pre-wrap;
   word-wrap: break-word;
-}
-
-.image-wrap{
-  overflow: hidden;
-  width: 100%;/* トリミングしたい枠の幅 */
-  height: 100%;/* トリミングしたい枠の高さ */
 }
 
 .visible-origin-xs {
@@ -350,9 +345,21 @@ a[href^="tel:"] {
     right: 0 !important;
     left: auto !important;
   }
+  .image-wrap{
+    position: relative;
+    overflow: hidden;
+    width: 100%;/* トリミングしたい枠の幅 */
+    height: 100%;/* トリミングしたい枠の高さ */
+    min-height: 200px;
+  }
   .shop-image{
+    position: absolute;
+    width: 560px;
     height: auto;
-    width: 120%;
+    left: 50%;
+    top: 50%;
+    -webkit-transform: translate3d(-50%, -50%, 0);
+    transform: translate3d(-50%, -50%, 0);
   }
   .shop-info-1{
     margin-top: 16px;
@@ -373,9 +380,20 @@ a[href^="tel:"] {
   .shop-name{
     padding-top: 8px;
   }
+  .image-wrap{
+    position: relative;
+    overflow: hidden;
+    width: 100%;/* トリミングしたい枠の幅 */
+    height: 100%;/* トリミングしたい枠の高さ */
+  }
   .shop-image{
-    height: 150%;
-    width: auto;
+    position: absolute;
+    width: 320px;
+    height: auto;
+    left: 50%;
+    top: 50%;
+    -webkit-transform: translate3d(-50%, -50%, 0);
+    transform: translate3d(-50%, -50%, 0);
   }
 }
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
-  <h2 class="main-text text-center page-heading mb-5 mt-5">パスワードをお忘れですか？</h2>
-  <p class="text-center main-text">ご登録頂きました「メールアドレス」を入力し、「送信する」を押してください。</p>
+  <h2 class="main-text text-center page-heading mb-5 mt-5 password-forget-title">パスワードをお忘れですか？</h2>
+  <p class="text-center main-text password-forget-guide">ご登録頂きました「メールアドレス」を入力し、「送信する」を押してください。</p>
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= devise_error_messages! %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,7 +5,7 @@
         <span class="copy">nomini from 2017</span>
       </div>
       <div class="nav-item contact-area">
-        <a href="http://line.me/R/ti/p/%40muv5134q" class="btn btn-outline-info contact-btn">LINE@でお問い合わせ</a>
+        <a href="http://line.me/R/ti/p/%40muv5134q" class="btn btn-outline-dark contact-btn">LINE@でお問い合わせ</a>
       </div>
     </nav>
   </div>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -6,7 +6,7 @@
 <div class="container">
   <% @shops.each do |shop| %>
     <div class="row bg-white mb-3 shop-list">
-      <div class="col-md-3 pb-2 picture-test">
+      <div class="col-md-3 pb-2 pt-2">
         <div class="image-wrap">
           <%= image_tag shop.image, size: '50x50', class: "align-self-center shop-image pt-2" %>
         </div>
@@ -22,7 +22,7 @@
             <h3><%= shop_name_text(shop) %></h3>
           </div>
           <div class="col-md-2">
-            <%= link_to '詳細を見る', shop_path(shop), class: "float-md-right btn btn-info shop-detail-btn" %>
+            <%= link_to '詳細を見る', shop_path(shop), class: "float-md-right btn main-btn shop-detail-btn" %>
           </div>
 
           <p class="shop-description mb-0 p-2">
@@ -31,7 +31,7 @@
           <div class="row w-100 pl-4 pb-2">
             <% shop.shop_usages.each do |shop_usage| %>
               <% unless shop_usage.price.blank? %>
-                <div class="col-4 course-price border border-info p-0 pl-2 pr-2 border-top-0 border-bottom-0 border-right-0">
+                <div class="col-4 course-price p-0 pl-2 pr-2">
                   <div class="row">
                     <span class="col-12 col-md-5"><%= shop_usage.reservation_category.name %></span>
                     <span class="col-12 col-md-7"><%= shop_usage.price %>円</span>


### PR DESCRIPTION
# 作業内容
- 店舗一覧画面の表示縦横比修正
- ボタンカラー等の微修正
- パスワード再発行画面のタイトルサイズの変更(モバイルのみ)