### PR TITLE
メールアドレス登録していてもfacebookログインが利用できるように修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,8 +30,10 @@ class User < ApplicationRecord
 
   # FaceBookログイン用
   def self.find_for_facebook_oauth(auth)
-    find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
+    find_or_create_by(email: auth.info.email) do |user|
       user.email = auth.info.email
+      user.provider = auth.provider
+      user.uid = auth.uid
       user.skip_confirmation!
     end
   end


### PR DESCRIPTION
## 概要
件名の対応
provider, uidをキーにしてレコードを検索していたところをemailに変えることでメールアドレス登録者でもfacebookログイン時にレコードに引っかかるように修正