### PR TITLE
管理画面上で招待ポイントの設定値を変更できるように修正

### DIFF
--- a/app/controllers/admin/system_settings_controller.rb
+++ b/app/controllers/admin/system_settings_controller.rb
@@ -1,0 +1,26 @@
+class Admin::SystemSettingsController < AdminController
+  before_action :set_system_settings
+
+  def index
+  end
+
+  def update
+    @system_setting = SystemSetting.find(params[:id])
+
+    if @system_setting.update(system_setting_params)
+      redirect_to admin_system_settings_url, notice: "#{@system_setting.logical_name}を修正しました"
+    else
+      render :index
+    end
+  end
+
+  private
+
+  def set_system_settings
+    @system_settings = SystemSetting.all
+  end
+
+  def system_setting_params
+    params.fetch(:system_setting, {}).permit(:value)
+  end
+end

--- a/app/controllers/admin/system_settings_controller.rb
+++ b/app/controllers/admin/system_settings_controller.rb
@@ -8,7 +8,7 @@ class Admin::SystemSettingsController < AdminController
     @system_setting = SystemSetting.find(params[:id])
 
     if @system_setting.update(system_setting_params)
-      redirect_to admin_system_settings_url, notice: "#{@system_setting.config_name}を修正しました"
+      redirect_to admin_system_settings_url, notice: t("system_setting.#{@system_setting.config_name}") + "を修正しました"
     else
       render :index
     end

--- a/app/controllers/admin/system_settings_controller.rb
+++ b/app/controllers/admin/system_settings_controller.rb
@@ -8,7 +8,7 @@ class Admin::SystemSettingsController < AdminController
     @system_setting = SystemSetting.find(params[:id])
 
     if @system_setting.update(system_setting_params)
-      redirect_to admin_system_settings_url, notice: "#{@system_setting.logical_name}を修正しました"
+      redirect_to admin_system_settings_url, notice: "#{@system_setting.config_name}を修正しました"
     else
       render :index
     end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -1,10 +1,12 @@
 class Exchange < ApplicationRecord
+  EXCHANGE_LINE = SystemSetting.exchange_line
+
   belongs_to :user
 
   enum status: { pending: 0, done: 1, remand: 2 }
 
   validates :point, presence: true,
-            numericality: { only_integer: true, greater_than_or_equal_to: 10_000 }
+            numericality: { only_integer: true, greater_than_or_equal_to: EXCHANGE_LINE }
   validate :less_than_possession_points
 
   after_create :update_point_balance

--- a/app/models/introduction.rb
+++ b/app/models/introduction.rb
@@ -1,7 +1,7 @@
 class Introduction < ApplicationRecord
 
   # 紹介したユーザーに加算されるポイント
-  INTRODUCTION_POINT = 2_000
+  INTRODUCTION_POINT = SystemSetting.introduction_point
 
   # Association
   belongs_to :user

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -1,0 +1,2 @@
+class SystemSetting < ApplicationRecord
+end

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -1,2 +1,15 @@
 class SystemSetting < ApplicationRecord
+  validates :logical_name, presence: true
+  validates :physical_name, presence: true
+  validates :value, presence: true
+
+  class << self
+    def introduction_point
+      find_by(physical_name: 'introduction').value
+    end
+
+    def exchange_line
+      find_by(physical_name: 'exchange').value
+    end
+  end
 end

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -1,15 +1,14 @@
 class SystemSetting < ApplicationRecord
-  validates :logical_name, presence: true
-  validates :physical_name, presence: true
+  validates :config_name, presence: true
   validates :value, presence: true
 
   class << self
     def introduction_point
-      find_by(physical_name: 'introduction').value
+      find_by(config_name: 'introduction').value
     end
 
     def exchange_line
-      find_by(physical_name: 'exchange').value
+      find_by(config_name: 'exchange').value
     end
   end
 end

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -58,6 +58,11 @@
           <i class="fa fa-beer"></i> <span>決済情報</span>
         <% end %>
       </li>
+      <li>
+        <%= link_to admin_system_settings_path do %>
+          <i class="fa fa-beer"></i> <span>ポイント設定</span>
+        <% end %>
+      </li>
     </ul>
   </section>
   <!-- /.sidebar -->

--- a/app/views/admin/system_settings/index.html.erb
+++ b/app/views/admin/system_settings/index.html.erb
@@ -6,7 +6,7 @@
   <div class="col-md-6">
     <div class="box box-primary">
       <div class="box-header">
-        <h3 class="box-title"><%= system_setting.config_name %></h3>
+        <h3 class="box-title"><%= t("system_setting.#{system_setting.config_name}") %></h3>
       </div>
       <div class="box-body">
         <%= form_with model: system_setting, url: admin_system_setting_path(system_setting), method: :patch, local: true do |form| %>
@@ -17,7 +17,7 @@
               </div>
             </div>
             <div class="col-md-3">
-              <%= form.submit '更新', class: 'btn btn-info', data: { confirm: "#{system_setting.config_name}を変更しますか？" } %>
+              <%= form.submit '更新', class: 'btn btn-info', data: { confirm: t("system_setting.#{system_setting.config_name}") + "を変更しますか？" } %>
             </div>
           </div>
         <% end %>

--- a/app/views/admin/system_settings/index.html.erb
+++ b/app/views/admin/system_settings/index.html.erb
@@ -6,7 +6,7 @@
   <div class="col-md-6">
     <div class="box box-primary">
       <div class="box-header">
-        <h3 class="box-title"><%= system_setting.logical_name %></h3>
+        <h3 class="box-title"><%= system_setting.config_name %></h3>
       </div>
       <div class="box-body">
         <%= form_with model: system_setting, url: admin_system_setting_path(system_setting), method: :patch, local: true do |form| %>
@@ -17,7 +17,7 @@
               </div>
             </div>
             <div class="col-md-3">
-              <%= form.submit '更新', class: 'btn btn-info', data: { confirm: "#{system_setting.logical_name}を変更しますか？" } %>
+              <%= form.submit '更新', class: 'btn btn-info', data: { confirm: "#{system_setting.config_name}を変更しますか？" } %>
             </div>
           </div>
         <% end %>

--- a/app/views/admin/system_settings/index.html.erb
+++ b/app/views/admin/system_settings/index.html.erb
@@ -1,0 +1,27 @@
+<% content_for :content_header do %>
+  <h1>ポイント設定</h1>
+<% end %>
+<!-- Main content -->
+<% @system_settings.each do |system_setting| %>
+  <div class="col-md-6">
+    <div class="box box-primary">
+      <div class="box-header">
+        <h3 class="box-title"><%= system_setting.logical_name %></h3>
+      </div>
+      <div class="box-body">
+        <%= form_with model: system_setting, url: admin_system_setting_path(system_setting), method: :patch, local: true do |form| %>
+          <div class="row">
+            <div class="col-md-9">
+              <div class="form-group">
+                <%= form.number_field :value, class: 'form-control', required: true %>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <%= form.submit '更新', class: 'btn btn-info', data: { confirm: "#{system_setting.logical_name}を変更しますか？" } %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/exchanges/new.html.erb
+++ b/app/views/exchanges/new.html.erb
@@ -18,7 +18,7 @@
         <h3 class="text-center current-point mb-4">現在のポイント数: <%= current_user.point_count %></h3>
         <p>
           下記入力フォームより換金したいポイント数を入力してください。<br>
-          ※ ポイントの換金は10,000ポイントからとなります。
+          ※ ポイントの換金は<%= Exchange::EXCHANGE_LINE %>ポイントからとなります。
         </p>
       </div>
       <div class="field form-group row signup-form">

--- a/app/views/introductions/new.html.erb
+++ b/app/views/introductions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container mt-3">
   <h2 class="main-text text-center page-heading mb-4 mt-4">友人紹介</h2>
-  <p class="text-center">紹介したご友人がnominiで店舗を利用すると、貴方に2000ポイントが付与されます。</p>
+  <p class="text-center">紹介したご友人がnominiで店舗を利用すると、貴方に<%= Introduction::INTRODUCTION_POINT %>ポイントが付与されます。</p>
   <%= form_for @introduction, url: introduction_path do |f| %>
     <div class="sign-up-countainer">
       <div class="field form-group center-form email-form">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -213,3 +213,6 @@ ja:
     invalid_expiry_month: 有効ではない有効期限月
     invalid_expiry_year: 有効ではない有効期限年
     expired_card: 有効期限切れ
+  system_setting:
+    introduction: 紹介ポイント
+    exchange: 最低換金額

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,5 +92,6 @@ Rails.application.routes.draw do
       patch :remand, on: :member
     end
     resources :reservation_payments
+    resources :system_settings, only: [:index, :update]
   end
 end

--- a/db/migrate/20180205145410_create_system_settings.rb
+++ b/db/migrate/20180205145410_create_system_settings.rb
@@ -1,0 +1,16 @@
+class CreateSystemSettings < ActiveRecord::Migration[5.1]
+  def change
+    ActiveRecord::Base.transaction do
+      create_table :system_settings do |t|
+        t.string :physical_name, index: true, null: false
+        t.string :logical_name, null: false
+        t.integer :value, null: false
+
+        t.timestamps
+      end
+
+      SystemSetting.create!(logical_name: '換金値', physical_name: 'exchange', value: 5_000)
+      SystemSetting.create!(logical_name: '招待ポイント', physical_name: 'introduction', value: 2_000)
+    end
+  end
+end

--- a/db/migrate/20180205145410_create_system_settings.rb
+++ b/db/migrate/20180205145410_create_system_settings.rb
@@ -2,15 +2,14 @@ class CreateSystemSettings < ActiveRecord::Migration[5.1]
   def change
     ActiveRecord::Base.transaction do
       create_table :system_settings do |t|
-        t.string :physical_name, index: true, null: false
-        t.string :logical_name, null: false
+        t.string :config_name, index: true, null: false
         t.integer :value, null: false
 
         t.timestamps
       end
 
-      SystemSetting.create!(logical_name: '換金値', physical_name: 'exchange', value: 5_000)
-      SystemSetting.create!(logical_name: '招待ポイント', physical_name: 'introduction', value: 2_000)
+      SystemSetting.create!(config_name: 'exchange', value: 5_000)
+      SystemSetting.create!(config_name: 'introduction', value: 2_000)
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219142648) do
+ActiveRecord::Schema.define(version: 20180205145410) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
@@ -216,6 +216,15 @@ ActiveRecord::Schema.define(version: 20171219142648) do
     t.date "trail_finished_on", null: false
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
+  end
+
+  create_table "system_settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "physical_name", null: false
+    t.string "logical_name", null: false
+    t.integer "value", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["physical_name"], name: "index_system_settings_on_physical_name"
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -219,12 +219,11 @@ ActiveRecord::Schema.define(version: 20180205145410) do
   end
 
   create_table "system_settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "physical_name", null: false
-    t.string "logical_name", null: false
+    t.string "config_name", null: false
     t.integer "value", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["physical_name"], name: "index_system_settings_on_physical_name"
+    t.index ["config_name"], name: "index_system_settings_on_config_name"
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/controllers/admin/system_settings_controller_spec.rb
+++ b/spec/controllers/admin/system_settings_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SystemSettingsController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/models/system_setting_spec.rb
+++ b/spec/models/system_setting_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SystemSetting, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/support/factories/system_settings.rb
+++ b/spec/support/factories/system_settings.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :system_setting do
+    physical_name "MyString"
+    logical_name "MyString"
+    value 1
+  end
+end


### PR DESCRIPTION
##概要
上記対応
招待ポイントと換金の下限値を管理画面から設定できるように修正
設定値をsystem_settingというモデルで管理するようにした

管理画面はこんな感じ
![2018-02-06 0 51 35](https://user-images.githubusercontent.com/14311071/35814234-e8533ba2-0ad8-11e8-9163-c6f459703574.png)

ひとまず初期値はmigrateのタイミングで作成してしまうようにしています