### PR TITLE
店舗画像を複数登録できるようにした

### DIFF
--- a/app/controllers/admin/shop_landscapes_controller.rb
+++ b/app/controllers/admin/shop_landscapes_controller.rb
@@ -1,0 +1,14 @@
+class Admin::ShopLandscapesController < ApplicationController
+  before_action :set_shop_landscape
+
+  def destroy
+    @shop_landscape.destroy
+    redirect_to edit_landscapes_admin_shop_url(@shop_landscape.shop), notice: '画像を削除しました'
+  end
+
+  private
+
+  def set_shop_landscape
+    @shop_landscape = ShopLandscape.find(params[:id])
+  end
+end

--- a/app/controllers/admin/shops_controller.rb
+++ b/app/controllers/admin/shops_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ShopsController < AdminController
-  before_action :set_shop, only: [:show, :edit, :update, :destroy]
+  before_action :set_shop, only: [:show, :edit, :update, :destroy, :edit_landscapes, :landscapes]
 
   def index
     @shops = Shop.page(params[:id])
@@ -45,6 +45,18 @@ class Admin::ShopsController < AdminController
     redirect_to admin_shops_url, notice: 'Shop was successfully destroyed.'
   end
 
+  def edit_landscapes
+    @shop.build_shop_landscapes
+  end
+
+  def landscapes
+    if @shop.update(shop_params)
+      redirect_to edit_landscapes_admin_shop_url(@shop), notice: '画像を登録しました'
+    else
+      render :edit_landscapes
+    end
+  end
+
   private
 
   def set_shop
@@ -55,7 +67,9 @@ class Admin::ShopsController < AdminController
     params.fetch(:shop, {}).permit(
       :email, :password, :password_confirmation, :name, :description, :prefecture_id, :city_code, :area_text,
       :address_detail, :image, :image_cache, :is_agree, :is_display,
-      :service_time, :price, :phone_number, shop_usages_attributes: [:id, :reservation_category_id, :price]
+      :service_time, :price, :phone_number,
+      shop_usages_attributes: [:id, :reservation_category_id, :price],
+      shop_landscapes_attributes: [:id, :image, :image_cache]
     )
   end
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -13,6 +13,7 @@ class Shop < ApplicationRecord
   belongs_to :prefecture, optional: true
 
   accepts_nested_attributes_for :shop_usages, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :shop_landscapes, allow_destroy: true, reject_if: :all_blank
 
   # Validation
   validates :name,     presence: true
@@ -44,6 +45,11 @@ class Shop < ApplicationRecord
   def build_shop_usages
     build_count = ReservationCategory.count - self.shop_usages.size
     build_count.times { self.shop_usages.build }
+  end
+
+  def build_shop_landscapes
+    build_count = ShopLandscape::LIMIT_COUNT - shop_landscapes.size
+    build_count.times { shop_landscapes.build }
   end
 
   def correct?(current_shop)

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -8,6 +8,7 @@ class Shop < ApplicationRecord
   has_many :reservations
   has_many :reservation_categories, through: :shop_usages
   has_many :shop_usages, dependent: :destroy
+  has_many :shop_landscapes, dependent: :destroy
   belongs_to :city, foreign_key: :city_code, primary_key: :city_code, optional: true
   belongs_to :prefecture, optional: true
 

--- a/app/models/shop_landscape.rb
+++ b/app/models/shop_landscape.rb
@@ -1,4 +1,6 @@
 class ShopLandscape < ApplicationRecord
+  LIMIT_COUNT = 10
+
   belongs_to :shop
 
   validates :image, presence: true

--- a/app/models/shop_landscape.rb
+++ b/app/models/shop_landscape.rb
@@ -1,0 +1,7 @@
+class ShopLandscape < ApplicationRecord
+  belongs_to :shop
+
+  validates :image, presence: true
+
+  mount_uploader :image, ShopImageUploader
+end

--- a/app/uploaders/shop_image_uploader.rb
+++ b/app/uploaders/shop_image_uploader.rb
@@ -3,6 +3,10 @@ class ShopImageUploader < CarrierWave::Uploader::Base
 
   Rails.env.production? ? (storage :fog) : (storage :file)
 
+  version :thumb do
+    process resize_to_fill: [140, 100]
+  end
+
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{model.id}"
   end

--- a/app/views/admin/shops/edit_landscapes.html.erb
+++ b/app/views/admin/shops/edit_landscapes.html.erb
@@ -12,6 +12,7 @@
           <%= landscape_form.hidden_field :image_cache %>
           <% if landscape_form.object.image.present? %>
             <%= image_tag landscape_form.object.image_url(:thumb) %>
+            <%= link_to '削除', admin_shop_landscape_url(landscape_form.object), class: 'btn btn-danger', method: :delete, data: { confirm: '削除してよろしいですか？' } %>
           <% end %>
         <% end %>
         <div class="box-footer">

--- a/app/views/admin/shops/edit_landscapes.html.erb
+++ b/app/views/admin/shops/edit_landscapes.html.erb
@@ -1,0 +1,23 @@
+<% content_for :content_header do %>
+  <h1>店舗画像登録</h1>
+<% end %>
+<!-- Main content -->
+<div class="col-md-12">
+  <div class="box box-primary">
+    <div class="box-body">
+      <%= bootstrap_form_for @shop, url: landscapes_admin_shop_path(@shop), method: :patch do |form| %>
+        <%= form.fields_for :shop_landscapes do |landscape_form| %>
+          <%= landscape_form.hidden_field :id %>
+          <%= landscape_form.file_field :image %>
+          <%= landscape_form.hidden_field :image_cache %>
+          <% if landscape_form.object.image.present? %>
+            <%= image_tag landscape_form.object.image_url(:thumb) %>
+          <% end %>
+        <% end %>
+        <div class="box-footer">
+          <%= form.primary '登録する' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shops/show.html.erb
+++ b/app/views/admin/shops/show.html.erb
@@ -117,6 +117,9 @@
       <%= link_to edit_admin_shop_path(@shop), class: 'btn btn-info' do %>
         <i class="fa fa-edit">編集</i>
       <% end %>
+      <%= link_to edit_landscapes_admin_shop_path(@shop), class: 'btn btn-info' do %>
+        <i class="fa fa-edit">画像登録</i>
+      <% end %>
       <%= link_to admin_shop_path(@shop), class: 'btn btn-danger', method: :delete, data: { confirm: '本当に削除してもよろしいですか？' } do %>
         <i class="fa fa-trash-o">削除</i>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,12 @@ Rails.application.routes.draw do
     only: :session
   namespace :admin do
     get :dashboard
-    resources :shops
+    resources :shops do
+      member do
+        get :edit_landscapes
+        patch :landscapes
+      end
+    end
     resources :reservation_categories
     resources :enquete_items
     resources :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
         patch :landscapes
       end
     end
+    resources :shop_landscapes, only: :destroy
     resources :reservation_categories
     resources :enquete_items
     resources :users

--- a/db/migrate/20180217132052_create_shop_landscapes.rb
+++ b/db/migrate/20180217132052_create_shop_landscapes.rb
@@ -1,0 +1,10 @@
+class CreateShopLandscapes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :shop_landscapes do |t|
+      t.references :shop, foreign_key: true, null: false
+      t.string :image, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180205145410) do
+ActiveRecord::Schema.define(version: 20180217132052) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
@@ -166,6 +166,14 @@ ActiveRecord::Schema.define(version: 20180205145410) do
     t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 
+  create_table "shop_landscapes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "shop_id", null: false
+    t.string "image", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shop_id"], name: "index_shop_landscapes_on_shop_id"
+  end
+
   create_table "shop_usages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "shop_id"
     t.bigint "reservation_category_id"
@@ -271,6 +279,7 @@ ActiveRecord::Schema.define(version: 20180205145410) do
   add_foreign_key "reservations", "reservation_categories"
   add_foreign_key "reservations", "shops"
   add_foreign_key "reservations", "users"
+  add_foreign_key "shop_landscapes", "shops"
   add_foreign_key "shop_usages", "reservation_categories"
   add_foreign_key "shop_usages", "shops"
   add_foreign_key "subscriptions", "users"

--- a/spec/controllers/admin/shop_landscapes_controller_spec.rb
+++ b/spec/controllers/admin/shop_landscapes_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ShopLandscapesController, type: :controller do
+
+end

--- a/spec/models/shop_landscape_spec.rb
+++ b/spec/models/shop_landscape_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ShopLandscape, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/support/factories/shop_landscapes.rb
+++ b/spec/support/factories/shop_landscapes.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :shop_landscape do
+    shop nil
+    image "MyString"
+  end
+end


### PR DESCRIPTION
## 概要
店舗画像を複数登録できるように機能追加した
表まで対応するとPRが大きくなるので一旦登録するところまで対応

## 対応内容
* 複数画像を持つためにshop_landscapeモデルを作成
* サムネイル画像も保存するようにuploaderに追記
* 管理画面上で登録できるようにした
* 画像の削除もできるようにした

## 仕様
* 今まで画像を保存していたカラムは残し、そのまま運用するようにした
  * データ移行など考えなくて良いため
  * 今までの画像カラムはメイン画像的な扱いにする
* とりあえず10枚登録する感じで